### PR TITLE
feat(xueqiu): add 6 adapters for xueqiu.com

### DIFF
--- a/xueqiu/feed.js
+++ b/xueqiu/feed.js
@@ -1,0 +1,44 @@
+/* @meta
+{
+  "name": "xueqiu/feed",
+  "description": "获取雪球首页时间线（关注用户的动态）",
+  "domain": "xueqiu.com",
+  "args": {
+    "page": {"required": false, "description": "页码，默认 1"},
+    "count": {"required": false, "description": "每页数量，默认 20"}
+  },
+  "readOnly": true,
+  "example": "bb-browser site xueqiu/feed"
+}
+*/
+
+async function(args) {
+  var page = parseInt(args.page) || 1;
+  var count = Math.min(parseInt(args.count) || 20, 50);
+  var resp = await fetch('https://xueqiu.com/v4/statuses/home_timeline.json?page=' + page + '&count=' + count, {credentials: 'include'});
+  if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Not logged in?'};
+  var d = await resp.json();
+
+  var strip = function(html) {
+    return (html || '').replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').trim();
+  };
+
+  var list = d.home_timeline || d.list || [];
+  var items = list.slice(0, count).map(function(item) {
+    var user = item.user || {};
+    return {
+      id: item.id,
+      text: strip(item.description).substring(0, 200),
+      url: 'https://xueqiu.com/' + user.id + '/' + item.id,
+      author: user.screen_name,
+      author_id: user.id,
+      verified: user.verified_description || null,
+      likes: item.fav_count,
+      retweets: item.retweet_count,
+      replies: item.reply_count,
+      created_at: item.created_at ? new Date(item.created_at).toISOString() : null
+    };
+  });
+
+  return {page: page, count: items.length, items: items};
+}

--- a/xueqiu/hot-stock.js
+++ b/xueqiu/hot-stock.js
@@ -1,0 +1,37 @@
+/* @meta
+{
+  "name": "xueqiu/hot-stock",
+  "description": "获取雪球热门股票榜",
+  "domain": "xueqiu.com",
+  "args": {
+    "count": {"required": false, "description": "返回数量，默认 20，最大 50"},
+    "type": {"required": false, "description": "榜单类型：10=人气榜(默认) 12=关注榜"}
+  },
+  "readOnly": true,
+  "example": "bb-browser site xueqiu/hot-stock 10"
+}
+*/
+
+async function(args) {
+  var count = Math.min(parseInt(args.count) || 20, 50);
+  var type = args.type || '10';
+  var resp = await fetch('https://stock.xueqiu.com/v5/stock/hot_stock/list.json?size=' + count + '&type=' + type, {credentials: 'include'});
+  if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Not logged in?'};
+  var d = await resp.json();
+  if (!d.data || !d.data.items) return {error: '获取失败', raw: d};
+
+  var items = d.data.items.map(function(s, i) {
+    return {
+      rank: i + 1,
+      symbol: s.symbol,
+      name: s.name,
+      price: s.current,
+      changePercent: s.percent != null ? s.percent.toFixed(2) + '%' : null,
+      heat: s.value,
+      rank_change: s.rank_change,
+      url: 'https://xueqiu.com/S/' + s.symbol
+    };
+  });
+
+  return {type: type === '12' ? '关注榜' : '人气榜', count: items.length, items: items};
+}

--- a/xueqiu/hot.js
+++ b/xueqiu/hot.js
@@ -1,0 +1,42 @@
+/* @meta
+{
+  "name": "xueqiu/hot",
+  "description": "获取雪球热门动态",
+  "domain": "xueqiu.com",
+  "args": {
+    "count": {"required": false, "description": "返回数量，默认 20，最大 50"}
+  },
+  "readOnly": true,
+  "example": "bb-browser site xueqiu/hot 10"
+}
+*/
+
+async function(args) {
+  var count = Math.min(parseInt(args.count) || 20, 50);
+  var resp = await fetch('https://xueqiu.com/statuses/hot/listV3.json?source=hot&page=1', {credentials: 'include'});
+  if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Not logged in?'};
+  var d = await resp.json();
+  var list = (d.list || []).slice(0, count);
+
+  var strip = function(html) {
+    return (html || '').replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').trim();
+  };
+
+  var items = list.map(function(item, i) {
+    var user = item.user || {};
+    return {
+      rank: i + 1,
+      id: item.id,
+      text: strip(item.description).substring(0, 200),
+      url: 'https://xueqiu.com/' + user.id + '/' + item.id,
+      author: user.screen_name,
+      author_id: user.id,
+      likes: item.fav_count,
+      retweets: item.retweet_count,
+      replies: item.reply_count,
+      created_at: item.created_at ? new Date(item.created_at).toISOString() : null
+    };
+  });
+
+  return {count: items.length, items: items};
+}

--- a/xueqiu/search.js
+++ b/xueqiu/search.js
@@ -1,0 +1,38 @@
+/* @meta
+{
+  "name": "xueqiu/search",
+  "description": "搜索雪球股票（代码或名称）",
+  "domain": "xueqiu.com",
+  "args": {
+    "query": {"required": true, "description": "搜索关键词，如 茅台、AAPL、腾讯"},
+    "count": {"required": false, "description": "返回数量，默认 10"}
+  },
+  "readOnly": true,
+  "example": "bb-browser site xueqiu/search 茅台"
+}
+*/
+
+async function(args) {
+  if (!args.query) return {error: 'Missing argument: query'};
+  var count = Math.min(parseInt(args.count) || 10, 20);
+  var resp = await fetch('https://xueqiu.com/stock/search.json?code=' + encodeURIComponent(args.query) + '&size=' + count, {credentials: 'include'});
+  if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Not logged in?'};
+  var d = await resp.json();
+  var stocks = (d.stocks || []).map(function(s) {
+    var symbol = '';
+    if (s.exchange === 'SH' || s.exchange === 'SZ' || s.exchange === 'BJ') {
+      symbol = s.code.startsWith(s.exchange) ? s.code : s.exchange + s.code;
+    } else {
+      symbol = s.code;
+    }
+    return {
+      symbol: symbol,
+      name: s.name,
+      exchange: s.exchange,
+      price: s.current,
+      changePercent: s.percentage != null ? s.percentage.toFixed(2) + '%' : null,
+      url: 'https://xueqiu.com/S/' + symbol
+    };
+  });
+  return {keyword: args.query, count: stocks.length, results: stocks};
+}

--- a/xueqiu/stock.js
+++ b/xueqiu/stock.js
@@ -1,0 +1,59 @@
+/* @meta
+{
+  "name": "xueqiu/stock",
+  "description": "获取雪球股票实时行情",
+  "domain": "xueqiu.com",
+  "args": {
+    "symbol": {"required": true, "description": "股票代码，如 SH600519、SZ000858、AAPL、00700"}
+  },
+  "readOnly": true,
+  "example": "bb-browser site xueqiu/stock SH600519"
+}
+*/
+
+async function(args) {
+  if (!args.symbol) return {error: 'Missing argument: symbol', hint: '请输入股票代码，如 SH600519'};
+
+  var symbol = args.symbol.toUpperCase();
+  var resp = await fetch('https://stock.xueqiu.com/v5/stock/batch/quote.json?symbol=' + encodeURIComponent(symbol), {credentials: 'include'});
+  if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Not logged in?'};
+  var d = await resp.json();
+
+  if (!d.data || !d.data.items || d.data.items.length === 0) return {error: '未找到股票: ' + symbol};
+
+  function fmtAmount(v) {
+    if (v == null) return null;
+    if (Math.abs(v) >= 1e12) return (v / 1e12).toFixed(2) + '万亿';
+    if (Math.abs(v) >= 1e8) return (v / 1e8).toFixed(2) + '亿';
+    if (Math.abs(v) >= 1e4) return (v / 1e4).toFixed(2) + '万';
+    return v.toString();
+  }
+
+  var item = d.data.items[0];
+  var q = item.quote || {};
+  var m = item.market || {};
+
+  return {
+    name: q.name,
+    symbol: q.symbol,
+    exchange: q.exchange,
+    currency: q.currency,
+    price: q.current,
+    change: q.chg,
+    changePercent: q.percent != null ? q.percent.toFixed(2) + '%' : null,
+    open: q.open,
+    high: q.high,
+    low: q.low,
+    prevClose: q.last_close,
+    amplitude: q.amplitude != null ? q.amplitude.toFixed(2) + '%' : null,
+    volume: q.volume,
+    amount: fmtAmount(q.amount),
+    turnover_rate: q.turnover_rate != null ? q.turnover_rate.toFixed(2) + '%' : null,
+    marketCap: fmtAmount(q.market_capital),
+    floatMarketCap: fmtAmount(q.float_market_capital),
+    ytdPercent: q.current_year_percent != null ? q.current_year_percent.toFixed(2) + '%' : null,
+    market_status: m.status || null,
+    time: q.timestamp ? new Date(q.timestamp).toISOString() : null,
+    url: 'https://xueqiu.com/S/' + q.symbol
+  };
+}

--- a/xueqiu/watchlist.js
+++ b/xueqiu/watchlist.js
@@ -1,0 +1,35 @@
+/* @meta
+{
+  "name": "xueqiu/watchlist",
+  "description": "获取雪球自选股列表",
+  "domain": "xueqiu.com",
+  "args": {
+    "category": {"required": false, "description": "分类：1=自选(默认) 2=持仓 3=关注"}
+  },
+  "readOnly": true,
+  "example": "bb-browser site xueqiu/watchlist"
+}
+*/
+
+async function(args) {
+  var category = parseInt(args.category) || 1;
+  var resp = await fetch('https://stock.xueqiu.com/v5/stock/portfolio/stock/list.json?size=100&category=' + category + '&pid=-1', {credentials: 'include'});
+  if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Not logged in?'};
+  var d = await resp.json();
+  if (!d.data || !d.data.stocks) return {error: '获取失败，可能未登录', raw: d};
+
+  var items = d.data.stocks.map(function(s) {
+    return {
+      symbol: s.symbol,
+      name: s.name,
+      price: s.current,
+      change: s.chg,
+      changePercent: s.percent != null ? s.percent.toFixed(2) + '%' : null,
+      volume: s.volume,
+      url: 'https://xueqiu.com/S/' + s.symbol
+    };
+  });
+
+  var labels = {1: '自选股', 2: '持仓', 3: '关注'};
+  return {category: labels[category] || category, count: items.length, items: items};
+}


### PR DESCRIPTION
## Summary

- Add 6 site adapters for [xueqiu.com](https://xueqiu.com) (雪球), a popular Chinese investment & stock community
- All adapters are **Tier 1** (Cookie auth via `fetch`, no extra headers or signing needed)

### Adapters

| Adapter | Description |
|---------|-------------|
| `xueqiu/hot` | Trending posts (热门动态) |
| `xueqiu/feed` | Home timeline from followed users |
| `xueqiu/stock` | Real-time stock quote by symbol (A-share, HK, US) |
| `xueqiu/search` | Search stocks by name or code |
| `xueqiu/hot-stock` | Popular stocks ranking (人气榜/关注榜) |
| `xueqiu/watchlist` | User's watchlist portfolio (自选股) |

## Test plan

- [x] `bb-browser site xueqiu/hot 3` — returns top 3 trending posts with author, likes, retweets
- [x] `bb-browser site xueqiu/feed` — returns home timeline posts
- [x] `bb-browser site xueqiu/stock SH600519` — returns 贵州茅台 quote with price, change, market cap
- [x] `bb-browser site xueqiu/search 茅台` — returns matching stock with correct symbol
- [x] `bb-browser site xueqiu/hot-stock 3` — returns top 3 popular stocks with heat score
- [x] `bb-browser site xueqiu/watchlist` — returns user's watchlist (empty if none added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)