### PR TITLE
feat(twitter): add bookmarks adapter

### DIFF
--- a/twitter/bookmarks.js
+++ b/twitter/bookmarks.js
@@ -1,0 +1,73 @@
+/* @meta
+{
+  "name": "twitter/bookmarks",
+  "description": "获取 Twitter 书签列表",
+  "domain": "x.com",
+  "args": {
+    "count": {"required": false, "description": "Number of bookmarks to return (default 20)"}
+  },
+  "capabilities": ["network"],
+  "readOnly": true,
+  "example": "bb-browser site twitter/bookmarks --count 10"
+}
+*/
+
+async function(args) {
+  const ct0 = document.cookie.split(';').map(c=>c.trim()).find(c=>c.startsWith('ct0='))?.split('=')[1];
+  if (!ct0) return {error: 'No ct0 cookie', hint: 'Not logged into x.com. Open x.com and log in first.'};
+  const bearer = decodeURIComponent('AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA');
+  const _h = {'Authorization':'Bearer '+bearer, 'X-Csrf-Token':ct0, 'X-Twitter-Auth-Type':'OAuth2Session', 'X-Twitter-Active-User':'yes'};
+
+  const count = Math.min(parseInt(args.count) || 20, 100);
+  const variables = JSON.stringify({count, includePromotedContent: false});
+  const features = JSON.stringify({
+    rweb_video_screen_enabled: false, profile_label_improvements_pcf_label_in_post_enabled: true,
+    responsive_web_profile_redirect_enabled: false, rweb_tipjar_consumption_enabled: false,
+    verified_phone_label_enabled: false, creator_subscriptions_tweet_preview_api_enabled: true,
+    responsive_web_graphql_timeline_navigation_enabled: true,
+    responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+    premium_content_api_read_enabled: false, communities_web_enable_tweet_community_results_fetch: true,
+    c9s_tweet_anatomy_moderator_badge_enabled: true,
+    articles_preview_enabled: true, responsive_web_edit_tweet_api_enabled: true,
+    graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+    view_counts_everywhere_api_enabled: true, longform_notetweets_consumption_enabled: true,
+    responsive_web_twitter_article_tweet_consumption_enabled: true,
+    tweet_awards_web_tipping_enabled: false,
+    content_disclosure_indicator_enabled: true, content_disclosure_ai_generated_indicator_enabled: true,
+    freedom_of_speech_not_reach_fetch_enabled: true, standardized_nudges_misinfo: true,
+    tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+    longform_notetweets_rich_text_read_enabled: true, longform_notetweets_inline_media_enabled: false,
+    responsive_web_enhance_cards_enabled: false
+  });
+  const url = '/i/api/graphql/Fy0QMy4q_aZCpkO0PnyLYw/Bookmarks?variables=' + encodeURIComponent(variables) + '&features=' + encodeURIComponent(features);
+  const resp = await fetch(url, {headers: _h, credentials: 'include'});
+  if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'queryId may have changed. Check network tab on x.com/i/bookmarks.'};
+  const d = await resp.json();
+
+  const instructions = d.data?.bookmark_timeline_v2?.timeline?.instructions || d.data?.bookmark_timeline?.timeline?.instructions || [];
+  let tweets = [], seen = new Set();
+  for (const inst of instructions) {
+    for (const entry of (inst.entries || [])) {
+      const r = entry.content?.itemContent?.tweet_results?.result;
+      if (!r) continue;
+      const tw = r.tweet || r;
+      const l = tw.legacy || {};
+      if (!tw.rest_id || seen.has(tw.rest_id)) continue;
+      seen.add(tw.rest_id);
+      const u = tw.core?.user_results?.result;
+      const nt = tw.note_tweet?.note_tweet_results?.result?.text;
+      const screenName = u?.legacy?.screen_name || u?.core?.screen_name;
+      tweets.push({
+        id: tw.rest_id, author: screenName,
+        name: u?.legacy?.name || u?.core?.name,
+        url: 'https://x.com/' + (screenName || '_') + '/status/' + tw.rest_id,
+        text: nt || l.full_text || '',
+        likes: l.favorite_count, retweets: l.retweet_count,
+        in_reply_to: l.in_reply_to_status_id_str || undefined,
+        created_at: l.created_at
+      });
+    }
+  }
+
+  return {count: tweets.length, tweets};
+}


### PR DESCRIPTION
## Summary
- Add `twitter/bookmarks` adapter: fetch your bookmarked tweets with structured JSON output

## Usage
```bash
bb-browser site twitter/bookmarks          # default 20 bookmarks
bb-browser site twitter/bookmarks 10       # specify count
```

## Details
- Uses GraphQL `Bookmarks` endpoint (`Fy0QMy4q_aZCpkO0PnyLYw`)
- Standard Tier 2 auth (bearer + ct0 cookie), no `x-client-transaction-id` required
- Returns: id, author, name, url, text, likes, retweets, created_at
- Deduplication via `Set` to avoid repeated entries
- Supports long tweets via `note_tweet` fallback

## Test plan
- [x] Tested with default count (20) — returns bookmarked tweets
- [x] Tested with `--count 5` — correctly limits results
- [x] Verified tweet URLs are correctly constructed

🤖 Generated with [Claude Code](https://claude.com/claude-code)