### PR TITLE
fix(twitter/thread): use Recency ranking and add cursor pagination

### DIFF
--- a/twitter/thread.js
+++ b/twitter/thread.js
@@ -23,12 +23,6 @@ async function(args) {
   const urlMatch = tweetId.match(/\/status\/(\d+)/);
   if (urlMatch) tweetId = urlMatch[1];
 
-  const variables = JSON.stringify({
-    focalTweetId: tweetId, referrer: 'tweet', with_rux_injections: false,
-    includePromotedContent: false, rankingMode: 'Relevance',
-    withCommunity: true, withQuickPromoteEligibilityTweetFields: true,
-    withBirdwatchNotes: true, withVoice: true
-  });
   const features = JSON.stringify({
     responsive_web_graphql_exclude_directive_enabled: true, verified_phone_label_enabled: false,
     creator_subscriptions_tweet_preview_api_enabled: true, responsive_web_graphql_timeline_navigation_enabled: true,
@@ -37,44 +31,64 @@ async function(args) {
     longform_notetweets_inline_media_enabled: true, freedom_of_speech_not_reach_fetch_enabled: true
   });
   const fieldToggles = JSON.stringify({withArticleRichContentState: true, withArticlePlainText: false});
-  const url = '/i/api/graphql/nBS-WpgA6ZG0CyNHD517JQ/TweetDetail?variables=' + encodeURIComponent(variables) + '&features=' + encodeURIComponent(features) + '&fieldToggles=' + encodeURIComponent(fieldToggles);
-  const resp = await fetch(url, {headers: _h, credentials: 'include'});
-  if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Tweet may not exist or queryId expired'};
-  const d = await resp.json();
 
-  const instructions = d.data?.threaded_conversation_with_injections_v2?.instructions || d.data?.tweetResult?.result?.timeline?.instructions || [];
-  let tweets = [], seen = new Set();
-  for (const inst of instructions) {
-    for (const entry of (inst.entries || [])) {
-      const r = entry.content?.itemContent?.tweet_results?.result;
-      if (r) {
-        const tw = r.tweet || r; const l = tw.legacy || {};
-        if (tw.rest_id && !seen.has(tw.rest_id)) {
-          seen.add(tw.rest_id);
-          const u = tw.core?.user_results?.result;
-          const nt = tw.note_tweet?.note_tweet_results?.result?.text;
-          const screenName = u?.legacy?.screen_name || u?.core?.screen_name;
-          tweets.push({id: tw.rest_id, author: screenName, text: nt || l.full_text || '',
-            url: 'https://x.com/' + (screenName || '_') + '/status/' + tw.rest_id,
-            likes: l.favorite_count, retweets: l.retweet_count, in_reply_to: l.in_reply_to_status_id_str, created_at: l.created_at});
-        }
-      }
-      for (const item of (entry.content?.items || [])) {
-        const r2 = item.item?.itemContent?.tweet_results?.result;
-        if (r2) {
-          const tw = r2.tweet || r2; const l = tw.legacy || {};
-          if (tw.rest_id && !seen.has(tw.rest_id)) {
-            seen.add(tw.rest_id);
-            const u = tw.core?.user_results?.result;
-            const nt = tw.note_tweet?.note_tweet_results?.result?.text;
-            const screenName = u?.legacy?.screen_name || u?.core?.screen_name;
-            tweets.push({id: tw.rest_id, author: screenName, text: nt || l.full_text || '',
-              url: 'https://x.com/' + (screenName || '_') + '/status/' + tw.rest_id,
-              likes: l.favorite_count, retweets: l.retweet_count, in_reply_to: l.in_reply_to_status_id_str, created_at: l.created_at});
+  let tweets = [], seen = new Set(), cursor = null, maxPages = 5;
+
+  function extractTweet(r) {
+    if (!r) return;
+    const tw = r.tweet || r; const l = tw.legacy || {};
+    if (!tw.rest_id || seen.has(tw.rest_id)) return;
+    seen.add(tw.rest_id);
+    const u = tw.core?.user_results?.result;
+    const nt = tw.note_tweet?.note_tweet_results?.result?.text;
+    const screenName = u?.legacy?.screen_name || u?.core?.screen_name;
+    tweets.push({id: tw.rest_id, author: screenName, text: nt || l.full_text || '',
+      url: 'https://x.com/' + (screenName || '_') + '/status/' + tw.rest_id,
+      likes: l.favorite_count, retweets: l.retweet_count, in_reply_to: l.in_reply_to_status_id_str, created_at: l.created_at});
+  }
+
+  for (let page = 0; page < maxPages; page++) {
+    const vars = {
+      focalTweetId: tweetId, referrer: 'tweet', with_rux_injections: false,
+      includePromotedContent: false, rankingMode: 'Recency',
+      withCommunity: true, withQuickPromoteEligibilityTweetFields: true,
+      withBirdwatchNotes: true, withVoice: true
+    };
+    if (cursor) vars.cursor = cursor;
+
+    const url = '/i/api/graphql/nBS-WpgA6ZG0CyNHD517JQ/TweetDetail?variables=' + encodeURIComponent(JSON.stringify(vars)) + '&features=' + encodeURIComponent(features) + '&fieldToggles=' + encodeURIComponent(fieldToggles);
+    const resp = await fetch(url, {headers: _h, credentials: 'include'});
+    if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Tweet may not exist or queryId expired'};
+    const d = await resp.json();
+
+    const instructions = d.data?.threaded_conversation_with_injections_v2?.instructions || d.data?.tweetResult?.result?.timeline?.instructions || [];
+    let nextCursor = null;
+
+    for (const inst of instructions) {
+      for (const entry of (inst.entries || [])) {
+        // Extract cursor for pagination
+        if (entry.content?.entryType === 'TimelineTimelineCursor' || entry.content?.__typename === 'TimelineTimelineCursor') {
+          if (entry.content.cursorType === 'Bottom' || entry.content.cursorType === 'ShowMore') {
+            nextCursor = entry.content.value;
           }
+          continue;
+        }
+        // Also check entryId for cursor
+        if (entry.entryId?.startsWith('cursor-bottom-') || entry.entryId?.startsWith('cursor-showMore-')) {
+          const cv = entry.content?.itemContent?.value || entry.content?.value;
+          if (cv) nextCursor = cv;
+          continue;
+        }
+
+        extractTweet(entry.content?.itemContent?.tweet_results?.result);
+        for (const item of (entry.content?.items || [])) {
+          extractTweet(item.item?.itemContent?.tweet_results?.result);
         }
       }
     }
+
+    if (!nextCursor || nextCursor === cursor) break;
+    cursor = nextCursor;
   }
 
   return {tweet_id: tweetId, count: tweets.length, tweets};


### PR DESCRIPTION
## Summary

- Change `rankingMode` from `'Relevance'` to `'Recency'` — returns all replies chronologically instead of filtering by engagement
- Add cursor-based pagination (up to 5 pages) to fetch all replies on popular threads
- Extract `extractTweet()` helper to reduce duplication

## Before / After

| | Before | After |
|---|---|---|
| Replies fetched | 30 | 100 |
| Low-engagement replies | Missing | Included |
| Pagination | None | Up to 5 pages |

Tested on [this thread](https://x.com/yan5xu/status/2032858943874281782) (1100+ likes, 200+ RTs) — previously missed replies from @LeeAshram, @ch123ch1231, and many others.

Fixes #10

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>