### PR TITLE
fix(twitter/search): dynamic webpack module lookup

### DIFF
--- a/twitter/search.js
+++ b/twitter/search.js
@@ -19,12 +19,15 @@ async function(args) {
   const ct0 = document.cookie.split(';').map(c=>c.trim()).find(c=>c.startsWith('ct0='))?.split('=')[1];
   if (!ct0) return {error: 'No ct0 cookie', hint: 'Please log in to https://x.com first.'};
 
-  // Access webpack module to generate x-client-transaction-id
+  // Access webpack module to generate x-client-transaction-id (dynamic lookup)
   let __webpack_require__;
   const chunkId = '__bb_s_' + Date.now();
   window.webpackChunk_twitter_responsive_web.push([[chunkId], {}, (req) => { __webpack_require__ = req; }]);
-  const txMod = __webpack_require__(83914);
-  const genTxId = txMod.jJ;
+  let genTxId;
+  for (const id of Object.keys(__webpack_require__.m)) {
+    try { const mod = __webpack_require__(id); if (mod && typeof mod.jJ === 'function') { genTxId = mod.jJ; break; } } catch(e) {}
+  }
+  if (!genTxId) return {error: 'Cannot find transaction ID generator', hint: 'Twitter webpack modules may have changed'};
 
   const bearer = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
   const path = '/i/api/graphql/oKkjeoNFNQN7IeK7AHYc0A/SearchTimeline';


### PR DESCRIPTION
## Summary

- The `x-client-transaction-id` generator webpack module ID (`83914`) was hardcoded in `twitter/search.js`
- This ID changes with every Twitter deployment, causing the adapter to break with `TypeError: Cannot read properties of undefined (reading 'call')`
- Replaced with dynamic lookup that iterates `__webpack_require__.m` to find the module exporting the `jJ` function

## Before
```js
const txMod = __webpack_require__(83914);
const genTxId = txMod.jJ;
```

## After
```js
let genTxId;
for (const id of Object.keys(__webpack_require__.m)) {
  try { const mod = __webpack_require__(id); if (mod && typeof mod.jJ === 'function') { genTxId = mod.jJ; break; } } catch(e) {}
}
if (!genTxId) return {error: 'Cannot find transaction ID generator', hint: 'Twitter webpack modules may have changed'};
```

## Test plan
- [x] `bb-browser site twitter/search "TSLA FSD 2026"` returns structured results
- [x] Verified current webpack module ID is `938838` (was `83914`), dynamic lookup handles both

🤖 Generated with [Claude Code](https://claude.com/claude-code)