### PR TITLE
feat(xiaohongshu/note): add video URL extraction

### DIFF
--- a/xiaohongshu/note.js
+++ b/xiaohongshu/note.js
@@ -1,7 +1,7 @@
 /* @meta
 {
   "name": "xiaohongshu/note",
-  "description": "Get Xiaohongshu note details",
+  "description": "Get Xiaohongshu note details (includes video download URLs for video notes)",
   "domain": "www.xiaohongshu.com",
   "args": {
     "note_id": {"required": true, "description": "Note ID or full note URL"}
@@ -173,6 +173,56 @@ async function(args) {
         url: parsed.noteId && xsecToken ? buildNoteUrl(parsed.noteId, xsecToken) : null
       };
     }
+    function extractVideoInfo(note) {
+      if (!note || note.type !== "video") return null;
+      const video = note.video;
+      if (!video) return null;
+      const stream = video.media?.stream;
+      if (!stream) return null;
+      const formats = [];
+      if (Array.isArray(stream.h264)) {
+        for (const s of stream.h264) {
+          if (s.masterUrl) {
+            formats.push({
+              quality: s.quality || "h264",
+              resolution: s.video?.width && s.video?.height ? `${s.video.width}x${s.video.height}` : null,
+              url: s.masterUrl,
+              size: s.size || null,
+              duration: s.video?.duration || video.capa?.duration || null
+            });
+          }
+        }
+      }
+      if (Array.isArray(stream.h265)) {
+        for (const s of stream.h265) {
+          if (s.masterUrl) {
+            formats.push({
+              quality: s.quality || "h265",
+              resolution: s.video?.width && s.video?.height ? `${s.video.width}x${s.video.height}` : null,
+              url: s.masterUrl,
+              size: s.size || null,
+              duration: s.video?.duration || video.capa?.duration || null
+            });
+          }
+        }
+      }
+      if (formats.length === 0 && video.url) {
+        formats.push({
+          quality: "default",
+          url: video.url,
+          resolution: null,
+          size: null,
+          duration: video.capa?.duration || null
+        });
+      }
+      return {
+        has_video: true,
+        duration: video.capa?.duration || null,
+        width: video.capa?.width || null,
+        height: video.capa?.height || null,
+        formats: formats
+      };
+    }
     async function navigate(path, query, waitMs = 1500) {
       const router = getRouter();
       if (!router) throw new Error("Router not found");
@@ -219,7 +269,8 @@ async function(args) {
       buildNoteUrl,
       rememberNoteTokens,
       resolveNoteIdentity,
-      openNoteAndWait
+      openNoteAndWait,
+      extractVideoInfo
     };
   })());
 
@@ -256,6 +307,10 @@ async function(args) {
 
   const token = note.xsecToken ?? resolved.xsecToken;
   helper.rememberNoteTokens([{ id: resolved.noteId, xsecToken: token, noteCard: { noteId: resolved.noteId } }]);
+
+  // Extract video info if this is a video note
+  const video = helper.extractVideoInfo(note);
+
   return {
     note_id: resolved.noteId,
     xsec_token: token,
@@ -275,6 +330,7 @@ async function(args) {
       : [],
     created_time: note.time ?? null,
     last_update_time: note.lastUpdateTime ?? null,
-    ip_location: note.ipLocation ?? null
+    ip_location: note.ipLocation ?? null,
+    video: video
   };
 }


### PR DESCRIPTION
## Summary

Enhance the xiaohongshu/note adapter to expose video download URLs for video notes.

## Changes

- Add \`extractVideoInfo()\` helper function to parse video stream data
- Extract H.264 and H.265 format variants with quality/resolution info
- Include direct download URLs (\`masterUrl\`) for each format
- Return video metadata: duration, width, height, file size

## Usage

For video notes, the response now includes a \`video\` field:

\`\`\`json
{
  \"video\": {
    \"has_video\": true,
    \"duration\": 58.5,
    \"width\": 720,
    \"height\": 1280,
    \"formats\": [
      {
        \"quality\": \"h264\",
        \"resolution\": \"720x1280\",
        \"url\": \"http://sns-video-bd.xhscdn.com/.../xxx.mp4\",
        \"size\": 171234567,
        \"duration\": 58.5
      }
    ]
  }
}
\`\`\`

For image notes, \`video\` is \`null\`.

## Testing

Tested with both video and image notes to ensure backward compatibility.