### PR TITLE
feat(wsj): Add WSJ site adapters

### DIFF
--- a/wsj/frontpage.js
+++ b/wsj/frontpage.js
@@ -1,0 +1,92 @@
+/* @meta
+{
+  "name": "wsj/frontpage",
+  "description": "WSJ print edition front page articles by date",
+  "domain": "www.wsj.com",
+  "args": {
+    "date": {"required": true, "description": "Print edition date in YYYYMMDD or YYYY-MM-DD"},
+    "count": {"required": false, "description": "Max results to return (default 30)"}
+  },
+  "readOnly": true,
+  "example": "bb-browser site wsj/frontpage 20260428"
+}
+*/
+
+async function(args) {
+  const normalizeDate = value => {
+    const raw = String(value || '').trim();
+    if (/^\d{8}$/.test(raw)) return raw;
+    const m = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    return m ? m[1] + m[2] + m[3] : '';
+  };
+  const readNextData = doc => {
+    try {
+      const el = doc.querySelector('#__NEXT_DATA__');
+      return el ? JSON.parse(el.textContent) : null;
+    } catch (e) {
+      return null;
+    }
+  };
+  const cleanUrl = url => {
+    if (!url) return '';
+    try {
+      const u = new URL(url, 'https://www.wsj.com');
+      return u.origin + u.pathname;
+    } catch (e) {
+      return url;
+    }
+  };
+  const normalizeAuthors = bylineData => {
+    if (!Array.isArray(bylineData)) return [];
+    const seen = new Set();
+    return bylineData
+      .map(x => x?.name || (x?.type === 'author' ? x.text : ''))
+      .filter(Boolean)
+      .filter(name => !seen.has(name) && seen.add(name));
+  };
+  const mapArticles = (items, group) => items.map((item, index) => ({
+    title: item.headline || '',
+    subtitle: item.summary || '',
+    time: item.timestamp || '',
+    authors: normalizeAuthors(item.bylineData),
+    url: cleanUrl(item.articleUrl || ''),
+    section: item.flashline || '',
+    group,
+    position: index + 1,
+    image: item.imageUrl || ''
+  })).filter(x => x.title && x.url);
+  const dedupeByUrlAndTitle = items => {
+    const seen = new Set();
+    return items.filter(item => {
+      const key = item.url + '|' + item.title;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  };
+
+  const date = normalizeDate(args.date || args._ || args[0]);
+  if (!date) return {error: 'Missing or invalid argument: date', hint: 'Use YYYYMMDD or YYYY-MM-DD, for example 20260428'};
+  const count = Math.min(parseInt(args.count) || 30, 80);
+  const path = '/print-edition/' + date + '/frontpage';
+
+  const resp = await fetch(path, {credentials: 'include'});
+  if (!resp.ok) return {error: 'HTTP ' + resp.status, date, hint: 'Make sure the print edition date exists and wsj.com is accessible'};
+
+  const html = await resp.text();
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const pageProps = readNextData(doc)?.props?.pageProps || {};
+  const articles = mapArticles(pageProps.articles || [], 'front_page');
+  const deduped = dedupeByUrlAndTitle(articles).slice(0, count);
+
+  return {
+    source: 'WSJ Print Edition',
+    date,
+    issueDate: pageProps.issueDate || date,
+    updatedTime: pageProps.updatedDatetimeUTC || '',
+    url: 'https://www.wsj.com' + path,
+    count: deduped.length,
+    articles: deduped,
+    hint: deduped.length ? undefined : 'No front page articles found in Next data'
+  };
+}

--- a/wsj/headlines.js
+++ b/wsj/headlines.js
@@ -1,0 +1,67 @@
+/* @meta
+{
+  "name": "wsj/headlines",
+  "description": "WSJ latest headlines",
+  "domain": "www.wsj.com",
+  "args": {
+    "count": {"required": false, "description": "Max results to return (default all)"}
+  },
+  "readOnly": true,
+  "example": "bb-browser site wsj/headlines 20"
+}
+*/
+
+async function(args) {
+  const readNextData = doc => {
+    try {
+      const el = doc.querySelector('#__NEXT_DATA__');
+      return el ? JSON.parse(el.textContent) : null;
+    } catch (e) {
+      return null;
+    }
+  };
+  const cleanUrl = url => {
+    if (!url) return '';
+    try {
+      const u = new URL(url, 'https://www.wsj.com');
+      return u.origin + u.pathname;
+    } catch (e) {
+      return url;
+    }
+  };
+  const normalizeAuthors = bylineData => {
+    if (!Array.isArray(bylineData)) return [];
+    const seen = new Set();
+    return bylineData
+      .map(x => x?.name || (x?.type === 'author' ? x.text : ''))
+      .filter(Boolean)
+      .filter(name => !seen.has(name) && seen.add(name));
+  };
+
+  const resp = await fetch('/news/latest-headlines?mod=wsjheader', {credentials: 'include'});
+  if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Make sure a wsj.com tab is open and accessible'};
+
+  const html = await resp.text();
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const rows = readNextData(doc)?.props?.pageProps?.latestHeadlines || [];
+  const count = args.count ? Math.min(parseInt(args.count) || rows.length, rows.length) : rows.length;
+
+  const headlines = rows.slice(0, count).map(item => ({
+    title: item.headline || '',
+    subtitle: item.summary || '',
+    time: item.timestamp || '',
+    authors: normalizeAuthors(item.bylineData),
+    url: cleanUrl(item.articleUrl || ''),
+    section: item.flashline || '',
+    type: item.type || '',
+    image: item.imageUrl || ''
+  })).filter(x => x.title && x.url);
+
+  return {
+    source: 'WSJ',
+    url: 'https://www.wsj.com/news/latest-headlines?mod=wsjheader',
+    count: headlines.length,
+    headlines,
+    hint: rows.length ? undefined : 'No latestHeadlines found in Next data'
+  };
+}

--- a/wsj/news.js
+++ b/wsj/news.js
@@ -1,0 +1,116 @@
+/* @meta
+{
+  "name": "wsj/news",
+  "description": "WSJ article full text by URL",
+  "domain": "www.wsj.com",
+  "args": {
+    "url": {"required": true, "description": "WSJ news URL"}
+  },
+  "readOnly": true,
+  "example": "bb-browser site wsj/news https://www.wsj.com/tech/ai/example-article-id"
+}
+*/
+
+async function(args) {
+  const toWsjPath = url => {
+    try {
+      const u = new URL(url, 'https://www.wsj.com');
+      if (!/(^|\.)wsj\.com$/.test(u.hostname)) return '';
+      return u.pathname + u.search;
+    } catch (e) {
+      return '';
+    }
+  };
+  const readNextData = doc => {
+    try {
+      const el = doc.querySelector('#__NEXT_DATA__');
+      return el ? JSON.parse(el.textContent) : null;
+    } catch (e) {
+      return null;
+    }
+  };
+  const extractText = value => {
+    if (!value) return '';
+    if (typeof value === 'string') return value;
+    if (Array.isArray(value)) return value.map(extractText).join('');
+    if (typeof value === 'object') {
+      if (typeof value.text === 'string') return value.text;
+      if (value.flattened) return extractText(value.flattened);
+      if (value.nested) return extractText(value.nested);
+      if (value.content) return extractText(value.content);
+      if (value.textAndDecorations) return extractText(value.textAndDecorations);
+    }
+    return '';
+  };
+  const getText = value => extractText(value).replace(/\s+/g, ' ').trim();
+  const extractBody = blocks => {
+    const out = [];
+    for (const block of blocks || []) {
+      if (!block || block.type !== 'paragraph') continue;
+      const value = extractText(block.content || block.textAndDecorations || block).replace(/\s+/g, ' ').trim();
+      if (value) out.push(value);
+    }
+    return out;
+  };
+  const getAltSummary = article => {
+    for (const item of article.flattenedAltSummaries || []) {
+      const value = getText(item?.descriptions?.[0]?.content);
+      if (value) return value.replace(/^EXCLUSIVE:\s*/i, '');
+    }
+    return '';
+  };
+  const normalizeAuthors = value => {
+    const seen = new Set();
+    return (Array.isArray(value) ? value : [])
+      .map(x => x?.name || x?.byline || x?.text || x?.content?.byline || '')
+      .filter(name => name && name.toLowerCase() !== 'by')
+      .filter(name => !seen.has(name) && seen.add(name));
+  };
+  const cleanUrl = url => {
+    if (!url) return '';
+    try {
+      const u = new URL(url, 'https://www.wsj.com');
+      return u.origin + u.pathname;
+    } catch (e) {
+      return url;
+    }
+  };
+  const text = el => (el?.textContent || '').replace(/\s+/g, ' ').trim();
+  const extractDomAuthors = doc => Array.from(new Set(Array.from(doc.querySelectorAll('[rel="author"], [class*="byline"] a, [class*="Byline"] a')).map(text).filter(Boolean)));
+
+  const inputUrl = args.url || args._ || args[0];
+  if (!inputUrl) return {error: 'Missing argument: url', hint: 'Provide a WSJ article URL'};
+  const path = toWsjPath(inputUrl);
+  if (!path) return {error: 'Invalid WSJ URL', hint: 'URL must be on wsj.com'};
+
+  const resp = await fetch(path, {credentials: 'include'});
+  if (!resp.ok) return {error: 'HTTP ' + resp.status, url: inputUrl, hint: 'Open wsj.com in browser and make sure the article is accessible'};
+
+  const html = await resp.text();
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const article = readNextData(doc)?.props?.pageProps?.articleData;
+
+  if (article) {
+    const paragraphs = extractBody(article.flattenedBody || []);
+    return {
+      source: 'WSJ',
+      url: cleanUrl(article.canonicalUrl || article.sourceUrl || inputUrl),
+      title: getText(article.headline) || getText(article.originalHeadline) || doc.title || '',
+      subtitle: getText(article.standFirst?.content) || getAltSummary(article) || '',
+      fullText: paragraphs.join('\n\n'),
+      paragraphs,
+      time: article.publishedDateTimeUtc || article.liveDateTimeUtc || '',
+      updatedTime: article.updatedDateTimeUtc || '',
+      authors: normalizeAuthors(article.authors || article.byline),
+      section: article.sectionName || article.articleType?.name || '',
+      flashline: getText(article.flashline) || getText(article.mobileFlashline?.flattened) || '',
+      id: article.id || article.originId || '',
+      wordCount: article.meta?.metrics?.wordCount || paragraphs.join(' ').split(/\s+/).filter(Boolean).length
+    };
+  }
+
+  const title = text(doc.querySelector('h1')) || doc.querySelector('meta[property="og:title"]')?.content || doc.title;
+  const subtitle = text(doc.querySelector('h2, [data-testid*="summary"], [class*="summary"]')) || doc.querySelector('meta[name="description"]')?.content || '';
+  const paragraphs = Array.from(doc.querySelectorAll('article p, [data-testid="article-body"] p')).map(text).filter(p => p.length > 20);
+  return {source: 'WSJ', url: cleanUrl(inputUrl), title, subtitle, fullText: paragraphs.join('\n\n'), paragraphs, time: doc.querySelector('time')?.getAttribute('datetime') || '', authors: extractDomAuthors(doc)};
+}

--- a/wsj/search.js
+++ b/wsj/search.js
@@ -1,0 +1,96 @@
+/* @meta
+{
+  "name": "wsj/search",
+  "description": "WSJ news search",
+  "domain": "www.wsj.com",
+  "args": {
+    "query": {"required": true, "description": "Search query"},
+    "count": {"required": false, "description": "Max results to return (default 20)"}
+  },
+  "readOnly": true,
+  "example": "bb-browser site wsj/search Trump"
+}
+*/
+
+async function(args) {
+  const readNextData = doc => {
+    try {
+      const el = doc.querySelector('#__NEXT_DATA__');
+      return el ? JSON.parse(el.textContent) : null;
+    } catch (e) {
+      return null;
+    }
+  };
+  const text = el => (el?.textContent || '').replace(/\s+/g, ' ').trim();
+  const cleanUrl = url => {
+    if (!url) return '';
+    try {
+      const u = new URL(url, 'https://www.wsj.com');
+      return u.origin + u.pathname;
+    } catch (e) {
+      return url;
+    }
+  };
+  const normalizeAuthors = bylineData => {
+    if (!Array.isArray(bylineData)) return [];
+    const seen = new Set();
+    return bylineData
+      .map(x => x?.name || (x?.type === 'author' ? x.text : ''))
+      .filter(Boolean)
+      .filter(name => !seen.has(name) && seen.add(name));
+  };
+  const firstLongText = (root, exclude) => {
+    for (const el of root.querySelectorAll('p, [class*="summary"], [class*="description"]')) {
+      const value = text(el);
+      if (value.length > 20 && value !== exclude) return value;
+    }
+    return '';
+  };
+
+  if (!args.query) return {error: 'Missing argument: query', hint: 'Provide a search query string'};
+  const count = Math.min(parseInt(args.count) || 20, 50);
+  const path = '/search?query=' + encodeURIComponent(args.query) + '&mod=searchresults_viewallresults';
+
+  const resp = await fetch(path, {credentials: 'include'});
+  if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Make sure a wsj.com tab is open and accessible'};
+
+  const html = await resp.text();
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const pageProps = readNextData(doc)?.props?.pageProps || {};
+  const rows = pageProps.searchResults || [];
+
+  if (rows.length > 0) {
+    const results = rows.slice(0, count).map(item => ({
+      title: item.headline || '',
+      subtitle: item.summary || '',
+      time: item.timestamp || '',
+      authors: normalizeAuthors(item.bylineData),
+      url: cleanUrl(item.articleUrl || ''),
+      section: item.flashline || item.seoPathValue || '',
+      printHeadline: item.printHeadline || '',
+      printPublicationDate: item.printPublicationDate || '',
+      image: item.imageUrl || ''
+    })).filter(x => x.title && x.url);
+    const entity = pageProps.searchEntityResult ? {
+      label: pageProps.searchEntityResult.label || '',
+      type: pageProps.searchEntityResult.type || '',
+      url: cleanUrl(pageProps.searchEntityResult.url || ''),
+      ctaText: pageProps.searchEntityResult.ctaText || ''
+    } : null;
+    return {query: args.query, source: 'WSJ', url: 'https://www.wsj.com' + path, total: pageProps.resultsCountMeta || '', entity, count: results.length, results};
+  }
+
+  const results = [];
+  const seen = new Set();
+  doc.querySelectorAll('article, li, div').forEach(node => {
+    if (results.length >= count) return;
+    const a = node.querySelector?.('a[href*="wsj.com"], a[href^="/"]');
+    if (!a) return;
+    const title = text(node.querySelector('h2,h3,h4') || a);
+    const url = cleanUrl(a.href || a.getAttribute('href') || '');
+    if (!title || !url || seen.has(url)) return;
+    seen.add(url);
+    results.push({title, subtitle: firstLongText(node, title), time: node.querySelector('time')?.getAttribute('datetime') || text(node.querySelector('time')), authors: [], url});
+  });
+  return {query: args.query, source: 'WSJ', count: results.length, results};
+}


### PR DESCRIPTION
## Description

  Adds WSJ adapters for use with bb-browser:

  - wsj/headlines: reads latest headlines from __NEXT_DATA__.props.pageProps.latestHeadlines
  - wsj/news: fetches a WSJ article by URL and extracts title, subtitle, authors, timestamps, and full article text
  - wsj/frontpage: reads print edition front-page articles for a specified date from __NEXT_DATA__.props.pageProps.articles
  - wsj/search: reads WSJ search results from __NEXT_DATA__.props.pageProps.searchResults

## Testing

  Tested locally with bb-browser site after copying the adapters into ~/.bb-browser/bb-sites/wsj:
```
  bb-browser site wsj/headlines --json
  bb-browser site wsj/search openai --json
  bb-browser site wsj/frontpage 20260428 --json
  bb-browser site wsj/news 'https://www.wsj.com/tech/ai/openai-misses-key-revenue-user-targets-in-high-stakes-sprint-toward-ipo-94a95273' --json
```
  All four adapters returned structured JSON successfully.