### PR TITLE
feat(hpms): add HPMS hotel management adapters

### DIFF
--- a/hpms/hotel-list.js
+++ b/hpms/hotel-list.js
@@ -1,0 +1,72 @@
+/* @meta
+{
+  "name": "hpms/hotel-list",
+  "description": "HPMS hotel list - get all hotels in the account",
+  "domain": "hpms.igotrip.cn",
+  "args": {
+    "page": {"required": false, "description": "Page number (default 1)"},
+    "page_size": {"required": false, "description": "Page size (default 20)"}
+  },
+  "capabilities": ["eval", "network"],
+  "readOnly": true,
+  "example": "bb-browser site hpms/hotel-list --page 1 --page_size 20"
+}
+*/
+
+async function(args) {
+  const page = parseInt(args.page) || 1;
+  const pageSize = parseInt(args.page_size) || 20;
+
+  // Step 1: Login to get fresh JWT token
+  const loginResponse = await fetch('https://gw.igotrip.cn/api/v2/hpms/org/user/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ account: 'zhong', password: 'C51718761' })
+  });
+  const loginData = await loginResponse.json();
+  if (!loginData.data || !loginData.data.access_token) {
+    return { error: 'Login failed: ' + JSON.stringify(loginData) };
+  }
+  const token = loginData.data.access_token;
+  localStorage.setItem('hpms_ty_access_token', token);
+
+  // Step 2: Fetch hotel list
+  // API returns nested: response.data = {code, message, count, data: [hotels]}
+  const url = `https://gw.igotrip.cn/api/v2/hpms/hotel/list?page_size=${pageSize}&page_index=${page}&need_count=true`;
+  const response = await fetch(url, {
+    headers: { 'Authorization': 'Bearer ' + token },
+    credentials: 'include'
+  });
+  const data = await response.json();
+
+  if (data.code && data.code !== 200) {
+    return { error: `HPMS API error: ${data.code} ${data.message}`, reason: data.reason };
+  }
+
+  // Navigate nested response: data.data = {code, message, count, data: [hotels]}
+  const inner = data.data || {};
+  const total = parseInt(inner.count) || 0;
+  const hotelArray = Array.isArray(inner.data) ? inner.data : [];
+
+  const hotels = hotelArray.map(h => ({
+    hotel_id: h.hotel_id,
+    name: h.name || '(无名称)',
+    province: h.province_name,
+    city: h.city_name,
+    area: h.area_name,
+    address: h.address_line,
+    contact: h.hotel_contact,
+    room_count: h.room_count,
+    status: h.supplier_hotel_status,
+    raw: h
+  }));
+
+  return {
+    page,
+    pageSize,
+    total,
+    token_expires_at: loginData.data.expires_at || '',
+    hotels
+  };
+}

--- a/hpms/order-list.js
+++ b/hpms/order-list.js
@@ -1,0 +1,79 @@
+/* @meta
+{
+  "name": "hpms/order-list",
+  "description": "HPMS order list - query recent orders from HPMS",
+  "domain": "hpms.igotrip.cn",
+  "args": {
+    "page": {"required": false, "description": "Page number (default 1)"},
+    "page_size": {"required": false, "description": "Page size (default 20)"}
+  },
+  "capabilities": ["eval", "network"],
+  "readOnly": true,
+  "example": "bb-browser site hpms/order-list --page 1 --page_size 20"
+}
+*/
+
+async function(args) {
+  const page = parseInt(args.page) || 1;
+  const pageSize = parseInt(args.page_size) || 20;
+  
+  // Step 1: Login to get fresh JWT token
+  const loginResponse = await fetch('https://gw.igotrip.cn/api/v2/hpms/org/user/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ account: 'zhong', password: 'C51718761' })
+  });
+  const loginData = await loginResponse.json();
+  if (!loginData.data || !loginData.data.access_token) {
+    return { error: 'Login failed: ' + JSON.stringify(loginData) };
+  }
+  const token = loginData.data.access_token;
+  localStorage.setItem('hpms_ty_access_token', token);
+  
+  // Step 2: Fetch order list
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - 30);
+  const startStr = startDate.toISOString().replace('T', ' ').slice(0, 19);
+  const endStr = new Date().toISOString().replace('T', ' ').slice(0, 19);
+  const url = `https://gw.igotrip.cn/api/v2/hpms/order/list?page=${page}&page_size=${pageSize}&created_at_start=${encodeURIComponent(startStr)}&created_at_end=${encodeURIComponent(endStr)}`;
+  
+  const result = await fetch(url, {
+    headers: { 'Authorization': 'Bearer ' + token },
+    credentials: 'include'
+  });
+  const data = await result.json();
+  
+  if (data.code && data.code !== 200) {
+    return { error: `HPMS API error: ${data.code} ${data.message}`, reason: data.reason };
+  }
+  
+  // Normalize: data.counts = total, data.result = orders array
+  const total = data.data && data.data.counts ? data.data.counts : 0;
+  const orders = (data.data && data.data.result ? data.data.result : []).map(order => ({
+    order_id: order.order_id,
+    distributor_order_id: order.distributor_order_id,
+    hotel_name: order.hotel_name,
+    room_name: order.room_name,
+    room_nights: order.room_nights_num,
+    check_in: order.check_in_time,
+    check_out: order.check_out_time,
+    status: order.order_status,
+    distributor: order.distributor_name,
+    supplier: order.supplier_name,
+    selling_price: order.order_amount ? order.order_amount / 100 : null, // in yuan
+    purchase_price: order.supplier_order_amount ? order.supplier_order_amount / 100 : null,
+    created_at: order.created_at,
+    update_at: order.update_at,
+    consumer: order.consumer,
+    raw: order
+  }));
+  
+  return {
+    page,
+    pageSize,
+    total,
+    token_expires_at: loginData.data.expires_at || '',
+    orders
+  };
+}

--- a/hpms/room-status.js
+++ b/hpms/room-status.js
@@ -1,0 +1,61 @@
+/* @meta
+{
+  "name": "hpms/room-status",
+  "description": "HPMS room status - query room availability and details for a hotel",
+  "domain": "hpms.igotrip.cn",
+  "args": {
+    "hotel_id": {"required": true, "description": "Hotel ID (e.g. 11469518)"}
+  },
+  "capabilities": ["eval", "network"],
+  "readOnly": true,
+  "example": "bb-browser site hpms/room-status --hotel_id 11469518"
+}
+*/
+
+async function(args) {
+  const hotelId = args.hotel_id;
+
+  // Step 1: Login to get fresh JWT token
+  const loginResponse = await fetch('https://gw.igotrip.cn/api/v2/hpms/org/user/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ account: 'zhong', password: 'C51718761' })
+  });
+  const loginData = await loginResponse.json();
+  if (!loginData.data || !loginData.data.access_token) {
+    return { error: 'Login failed: ' + JSON.stringify(loginData) };
+  }
+  const token = loginData.data.access_token;
+  localStorage.setItem('hpms_ty_access_token', token);
+
+  // Step 2: Fetch room status
+  // API returns: data.data = {rows: [rooms], count: total}
+  const roomUrl = `https://gw.igotrip.cn/api/v2/hpms/cms/room/hotel/query?hotel_id=${hotelId}&protocol_id=1`;
+  const roomResponse = await fetch(roomUrl, {
+    headers: { 'Authorization': 'Bearer ' + token },
+    credentials: 'include'
+  });
+  const data = await roomResponse.json();
+
+  if (data.code && data.code !== 200) {
+    return { error: `Room API error: ${data.code} ${data.message}`, reason: data.reason };
+  }
+
+  const inner = data.data || {};
+  const rooms = Array.isArray(inner.rows) ? inner.rows.map(r => ({
+    room_type_id: r.room_type_id || r.id,
+    room_type_name: r.room_type_name || r.name,
+    status: r.status,
+    available: r.available,
+    price: r.price,
+    raw: r
+  })) : [];
+
+  return {
+    hotel_id: hotelId,
+    token_expires_at: loginData.data.expires_at || '',
+    total: inner.count || 0,
+    rooms
+  };
+}


### PR DESCRIPTION
## HPMS (Hotel Property Management System) Adapters

Reverse-engineered HPMS OTA platform API (`gw.igotrip.cn`) with Tier 2 Bearer token authentication.

### Adapters

#### `hpms/order-list`
Query recent orders with full details (hotel, room, guest, prices, status).
```bash
bb-browser site hpms/order-list --page 1 --page_size 20
```

#### `hpms/hotel-list`
Query hotel list with 361k+ hotels (name, province, city, contact info).
```bash
bb-browser site hpms/hotel-list --page 1 --page_size 20
```

#### `hpms/room-status`
Query room availability and details for a specific hotel.
```bash
bb-browser site hpms/room-status --hotel_id 11469518
```

### Auth
- **Login**: `POST /api/v2/hpms/org/user/login` with `{"account":"zhong","password":"C51718761"}` → JWT Bearer token
- **Token expires**: ~July 2026
- **Storage**: Automatically stored in localStorage as `hpms_ty_access_token`

### API Base
`https://gw.igotrip.cn`

### Tier
**Tier 2** — Bearer token auth (~3 min reverse-engineering time)
