### PR TITLE
feat(459): add 459.org DOI resolution and search adapters

### DIFF
--- a/459/doi.js
+++ b/459/doi.js
@@ -1,0 +1,157 @@
+/* @meta
+{
+  "name": "459/doi",
+  "description": "通过 DOI 在 459.org 获取学术论文 PDF (Download paper by DOI from 459.org)",
+  "domain": "459.org",
+  "args": {
+    "doi": {"required": true, "description": "Paper DOI (e.g., 10.1126/science.aaa8415)"}
+  },
+  "readOnly": true,
+  "example": "bb-browser site 459/doi 10.1016/j.watres.2023.120123"
+}
+*/
+
+async function(args) {
+  if (!args.doi) return {error: 'Missing argument: doi', hint: 'Provide a DOI string'};
+
+  // Domain check
+  if (!location.hostname.includes('459.org')) {
+    return {error: 'Not on 459.org domain', hint: 'Open a 459.org tab first: bb-browser open http://www.459.org --tab'};
+  }
+
+  const doi = args.doi.trim();
+  // Sci-Hub accepts DOI directly in the path
+  const url = '/' + encodeURIComponent(doi);
+
+  let html = '';
+  try {
+    const resp = await fetch(url, {
+      credentials: 'include',
+      headers: {
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Referer': location.href
+      }
+    });
+    if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: '459.org service may be unavailable or paper not found'};
+    html = await resp.text();
+  } catch (e) {
+    return {error: 'Failed to fetch: ' + e.message, hint: 'Make sure a 459.org tab is open'};
+  }
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+
+  // Check for error indicators
+  const titleEl = doc.querySelector('title');
+  const titleText = titleEl ? titleEl.textContent : '';
+  if (titleText.includes('404') || titleText.includes('Not Found') || titleText.includes('error')) {
+    return {error: 'Paper not found for DOI: ' + doi, hint: 'The paper may not be in Sci-Hub database, or the DOI is incorrect'};
+  }
+
+  // Check for verification/captcha page
+  if (html.includes('Checking your browser') || html.includes('DDoS-Guard') || html.includes('captcha')) {
+    return {error: 'Security verification required', hint: 'Please complete the browser verification on the 459.org tab first'};
+  }
+
+  // Extract PDF link - try multiple strategies
+  let pdfUrl = '';
+  let paperTitle = '';
+
+  // Strategy 1: Look for embed or iframe with PDF
+  const embed = doc.querySelector('embed[src]');
+  const iframe = doc.querySelector('iframe[src]');
+  if (embed) {
+    pdfUrl = embed.getAttribute('src');
+  } else if (iframe) {
+    pdfUrl = iframe.getAttribute('src');
+  }
+
+  // Strategy 2: Look for direct PDF links
+  if (!pdfUrl) {
+    const links = doc.querySelectorAll('a[href]');
+    for (const a of links) {
+      const href = a.getAttribute('href');
+      if (href && (href.endsWith('.pdf') || href.includes('.pdf?'))) {
+        pdfUrl = href;
+        break;
+      }
+    }
+  }
+
+  // Strategy 3: Look for button or div with onclick containing pdf
+  if (!pdfUrl) {
+    const onclickEls = doc.querySelectorAll('[onclick*="pdf"], [onclick*="download"]');
+    for (const el of onclickEls) {
+      const onclick = el.getAttribute('onclick') || '';
+      const match = onclick.match(/['"]([^'"]*\.pdf[^'"]*)['"]/);
+      if (match) {
+        pdfUrl = match[1];
+        break;
+      }
+    }
+  }
+
+  // Strategy 4: Look for any element with data-pdf or similar attributes
+  if (!pdfUrl) {
+    const dataPdf = doc.querySelector('[data-pdf], [data-url], [data-file]');
+    if (dataPdf) {
+      pdfUrl = dataPdf.getAttribute('data-pdf') || dataPdf.getAttribute('data-url') || dataPdf.getAttribute('data-file');
+    }
+  }
+
+  // Strategy 5: Look for location.replace or redirect in script tags
+  if (!pdfUrl) {
+    const scripts = doc.querySelectorAll('script');
+    for (const script of scripts) {
+      const text = script.textContent || '';
+      const match = text.match(/location\.\w+\s*[=]\s*['"]([^'"]*\.pdf[^'"]*)['"]/);
+      if (match) {
+        pdfUrl = match[1];
+        break;
+      }
+    }
+  }
+
+  // Resolve relative URLs
+  if (pdfUrl && !pdfUrl.startsWith('http')) {
+    if (pdfUrl.startsWith('//')) {
+      pdfUrl = 'https:' + pdfUrl;
+    } else if (pdfUrl.startsWith('/')) {
+      pdfUrl = 'http://www.459.org' + pdfUrl;
+    } else {
+      pdfUrl = 'http://www.459.org/' + pdfUrl;
+    }
+  }
+
+  // Extract paper title if available
+  const heading = doc.querySelector('h1, h2, #title, .title, [class*="title"]');
+  if (heading) {
+    paperTitle = heading.textContent.trim();
+  }
+
+  // Extract author info if available
+  let authors = '';
+  const authorEl = doc.querySelector('.author, #author, [class*="author"]');
+  if (authorEl) {
+    authors = authorEl.textContent.trim();
+  }
+
+  if (!pdfUrl) {
+    return {
+      error: 'Could not extract PDF link from Sci-Hub response',
+      hint: 'The paper may not be available, or the page structure has changed. Try opening the DOI directly in browser: http://www.459.org/' + doi,
+      doi: doi,
+      title: paperTitle || undefined,
+      htmlPreview: html.substring(0, 500)
+    };
+  }
+
+  return {
+    doi: doi,
+    title: paperTitle || undefined,
+    authors: authors || undefined,
+    pdfUrl: pdfUrl,
+    note: '459.org PDF link extracted. Open the URL to download the paper.',
+    warning: 'This mirror may not be an official Sci-Hub domain. Use at your own risk.'
+  };
+}

--- a/459/search.js
+++ b/459/search.js
@@ -1,0 +1,191 @@
+/* @meta
+{
+  "name": "459/search",
+  "description": "459.org 学术文献搜索/DOI解析 (Search or resolve paper by DOI/title on 459.org)",
+  "domain": "459.org",
+  "args": {
+    "query": {"required": true, "description": "DOI, PMID, article title, or publisher URL"},
+    "count": {"required": false, "description": "Number of results (default 5, max 10)"}
+  },
+  "readOnly": true,
+  "example": "bb-browser site 459/search \"10.1126/science.aaa8415\""
+}
+*/
+
+async function(args) {
+  if (!args.query) return {error: 'Missing argument: query', hint: 'Provide a DOI, PMID, article title, or publisher URL'};
+
+  // Domain check
+  if (!location.hostname.includes('459.org')) {
+    return {error: 'Not on 459.org domain', hint: 'Open a 459.org tab first: bb-browser open http://www.459.org --tab'};
+  }
+
+  const query = args.query.trim();
+  const count = Math.min(parseInt(args.count) || 5, 10);
+
+  // Check if input is a DOI
+  const doiPattern = /^10\.\d{4,}\/.+/;
+  const isDoi = doiPattern.test(query);
+
+  // If DOI, use direct resolution
+  if (isDoi) {
+    const url = '/' + encodeURIComponent(query);
+    let html = '';
+    try {
+      const resp = await fetch(url, {
+        credentials: 'include',
+        headers: {
+          'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+          'Referer': location.href
+        }
+      });
+      if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Paper not found or Sci-Hub service unavailable'};
+      html = await resp.text();
+    } catch (e) {
+      return {error: 'Failed to fetch: ' + e.message, hint: 'Make sure a 459.org tab is open'};
+    }
+
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+
+    // Check for verification page
+    if (html.includes('Checking your browser') || html.includes('DDoS-Guard')) {
+      return {error: 'Security verification required', hint: 'Please complete the browser verification on the 459.org tab first'};
+    }
+
+    // Extract PDF link using multiple strategies
+    let pdfUrl = '';
+
+    const embed = doc.querySelector('embed[src]');
+    const iframe = doc.querySelector('iframe[src]');
+    if (embed) pdfUrl = embed.getAttribute('src');
+    else if (iframe) pdfUrl = iframe.getAttribute('src');
+
+    if (!pdfUrl) {
+      const links = doc.querySelectorAll('a[href]');
+      for (const a of links) {
+        const href = a.getAttribute('href');
+        if (href && (href.endsWith('.pdf') || href.includes('.pdf?'))) {
+          pdfUrl = href;
+          break;
+        }
+      }
+    }
+
+    if (!pdfUrl) {
+      const scripts = doc.querySelectorAll('script');
+      for (const script of scripts) {
+        const text = script.textContent || '';
+        const match = text.match(/location\.\w+\s*[=]\s*['"]([^'"]*\.pdf[^'"]*)['"]/);
+        if (match) { pdfUrl = match[1]; break; }
+      }
+    }
+
+    // Resolve relative URLs
+    if (pdfUrl && !pdfUrl.startsWith('http')) {
+      if (pdfUrl.startsWith('//')) pdfUrl = 'https:' + pdfUrl;
+      else if (pdfUrl.startsWith('/')) pdfUrl = 'http://www.459.org' + pdfUrl;
+      else pdfUrl = 'http://www.459.org/' + pdfUrl;
+    }
+
+    const titleEl = doc.querySelector('h1, h2, #title, .title');
+    const title = titleEl ? titleEl.textContent.trim() : '';
+
+    if (!pdfUrl) {
+      return {
+        error: 'Could not extract PDF for DOI: ' + query,
+        hint: 'The paper may not be available in Sci-Hub database',
+        doi: query,
+        title: title || undefined
+      };
+    }
+
+    return {
+      doi: query,
+      title: title || undefined,
+      pdfUrl: pdfUrl,
+      note: 'PDF link resolved. Open the URL to download the paper.',
+      warning: 'This mirror may not be an official Sci-Hub domain. Use at your own risk.'
+    };
+  }
+
+  // Not a DOI - try to search via Sci-Hub's search form if available
+  // Most Sci-Hub mirrors accept non-DOI queries via POST or GET to root
+  const searchUrl = '/?q=' + encodeURIComponent(query);
+  let html = '';
+  try {
+    const resp = await fetch(searchUrl, {
+      credentials: 'include',
+      headers: {
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Referer': location.href
+      }
+    });
+    if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Search failed'};
+    html = await resp.text();
+  } catch (e) {
+    return {error: 'Failed to search: ' + e.message};
+  }
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+
+  // Check for verification page
+  if (html.includes('Checking your browser') || html.includes('DDoS-Guard')) {
+    return {error: 'Security verification required', hint: 'Please complete the browser verification first'};
+  }
+
+  // Try to find multiple results (if Sci-Hub returns a list)
+  const results = [];
+  const items = doc.querySelectorAll('.result, .item, .paper, [class*="result"], [class*="item"]');
+
+  for (let i = 0; i < Math.min(items.length, count); i++) {
+    const item = items[i];
+    const titleLink = item.querySelector('a');
+    if (!titleLink) continue;
+
+    const title = titleLink.textContent.trim();
+    const href = titleLink.getAttribute('href') || '';
+
+    let pdfUrl = '';
+    const pdfLink = item.querySelector('a[href*=".pdf"]');
+    if (pdfLink) pdfUrl = pdfLink.getAttribute('href');
+
+    results.push({
+      title: title,
+      url: href.startsWith('http') ? href : (href.startsWith('/') ? 'http://www.459.org' + href : 'http://www.459.org/' + href),
+      pdfUrl: pdfUrl || undefined
+    });
+  }
+
+  if (results.length > 0) {
+    return {
+      query: query,
+      count: results.length,
+      results: results,
+      note: 'Search results from Sci-Hub.su'
+    };
+  }
+
+  // If no structured results, check if we got a single paper page
+  const embed = doc.querySelector('embed[src]');
+  const iframe = doc.querySelector('iframe[src]');
+  if (embed || iframe) {
+    const pdfSrc = embed ? embed.getAttribute('src') : iframe.getAttribute('src');
+    const titleEl = doc.querySelector('h1, h2, #title, .title');
+    return {
+      query: query,
+      note: 'Sci-Hub resolved the query to a single paper',
+      title: titleEl ? titleEl.textContent.trim() : undefined,
+      pdfUrl: pdfSrc && !pdfSrc.startsWith('http') ? (pdfSrc.startsWith('//') ? 'https:' + pdfSrc : 'http://www.459.org' + pdfSrc) : pdfSrc,
+      warning: 'This mirror may not be an official Sci-Hub domain. Use at your own risk.'
+    };
+  }
+
+  // No results found
+  return {
+    error: 'No results found for query: ' + query,
+    hint: 'Sci-Hub primarily supports DOI lookups. Try searching for the DOI on Google Scholar or PubMed first, then use: bb-browser site scihub-su/doi <DOI>',
+    query: query
+  };
+}


### PR DESCRIPTION
## Summary

Add bb-browser site adapters for 459.org Sci-Hub mirror:

- **459/doi** — Resolve paper PDF by DOI. Directly queries 459.org/DOI and extracts PDF links from the response page using multiple fallback strategies (embed, iframe, link, script redirect).

- **459/search** — Accepts DOI, PMID, title, or publisher URL. Automatically detects DOI format and uses direct resolution. Falls back to search form for non-DOI queries.

## Features

- Domain validation (459.org)
- Anti-bot bypass via Referer header
- DDoS-Guard / browser verification page detection
- Multiple PDF extraction strategies for robust parsing
- Structured error handling with actionable hints

## Usage

已打开: http://www.459.org
Tab ID: 97078C18837CDBFD9A013C947A6F76BA

💡 该网站有 2 个 site adapter 可直接获取数据，无需手动操作浏览器。试试: bb-browser site 459/doi 10.1016/j.watres.2023.120123

## Checklist

- [x] Adapter follows the @meta metadata format
- [x] Error handling follows project conventions
- [x] No destructive operations (readOnly: true)
- [x] Multiple fallback strategies for DOM parsing