### PR TITLE
feat(investing): add investing.com site adapters with earnings calendar

### DIFF
--- a/investing/chart.js
+++ b/investing/chart.js
@@ -1,0 +1,44 @@
+/* @meta
+{
+  "name": "investing/chart",
+  "description": "Get OHLCV chart data for any financial instrument",
+  "domain": "www.investing.com",
+  "args": {
+    "id": {"required": true, "description": "Instrument ID (use investing/search to find it)"},
+    "interval": {"required": false, "description": "Time interval: 1m/5m/15m/30m/1h/5h/1d/1w/1M (default: 1d)"},
+    "points": {"required": false, "description": "Number of data points: 60/70/90/110/120/140/160 (default: 60)"}
+  },
+  "capabilities": ["network"],
+  "readOnly": true,
+  "example": "bb-browser site investing/chart 6408 --interval 1d --points 60"
+}
+*/
+
+async function(args) {
+  if (!args.id) return {error: 'Missing argument: id'};
+
+  const intervalMap = {
+    '1m': 'PT1M', '5m': 'PT5M', '15m': 'PT15M', '30m': 'PT30M',
+    '1h': 'PT1H', '5h': 'PT5H', '1d': 'P1D', '1w': 'P1W', '1M': 'P1M'
+  };
+  const interval = intervalMap[args.interval] || args.interval || 'P1D';
+  const points = parseInt(args.points) || 60;
+
+  const url = 'https://api.investing.com/api/financialdata/' + args.id +
+    '/historical/chart/?interval=' + interval + '&pointscount=' + points;
+  const resp = await fetch(url);
+  if (!resp.ok) return {error: 'HTTP ' + resp.status};
+  const data = await resp.json();
+  if (data['@errors']) return {error: data['@errors'].join('; ')};
+
+  return {
+    instrument_id: parseInt(args.id),
+    interval: interval,
+    count: data.data?.length || 0,
+    data: (data.data || []).map(d => ({
+      time: new Date(d[0]).toISOString(),
+      open: d[1], high: d[2], low: d[3], close: d[4],
+      volume: d[5]
+    }))
+  };
+}

--- a/investing/earnings.js
+++ b/investing/earnings.js
@@ -1,0 +1,161 @@
+/* @meta
+{
+  "name": "investing/earnings",
+  "description": "Get upcoming earnings calendar with EPS/revenue forecasts for specified date range",
+  "domain": "www.investing.com",
+  "args": {
+    "from": {"required": false, "description": "Start date YYYY-MM-DD (default: today)"},
+    "to": {"required": false, "description": "End date YYYY-MM-DD (default: same as from, i.e. single day)"},
+    "country": {"required": false, "description": "Comma-separated country filter: us,china,hk,japan,uk,germany,france,india,brazil,canada,australia (default: all)"}
+  },
+  "capabilities": ["network"],
+  "readOnly": true,
+  "example": "bb-browser site investing/earnings --from 2026-06-01 --to 2026-06-06 --country us,china,hk"
+}
+*/
+
+async function(args) {
+  var today = new Date().toISOString().slice(0, 10);
+  var from = args.from || today;
+  var to = args.to || from;
+
+  // Country name -> investing.com country IDs
+  var countryMap = {
+    us: '5', usa: '5', 'united states': '5',
+    china: '35', cn: '35',
+    hk: '72', 'hong kong': '72',
+    japan: '36', jp: '36',
+    uk: '4', gb: '4', 'united kingdom': '4',
+    germany: '17', de: '17',
+    france: '22', fr: '22',
+    india: '14', 'in': '14',
+    brazil: '32', br: '32',
+    canada: '6', ca: '6',
+    australia: '25', au: '25',
+    korea: '11', kr: '11', 'south korea': '11',
+    singapore: '36', sg: '36',
+    taiwan: '46', tw: '46',
+    switzerland: '42', ch: '42',
+    netherlands: '21', nl: '21',
+    spain: '26', es: '26',
+    italy: '10', it: '10',
+    sweden: '9', se: '9',
+    norway: '60', no: '60'
+  };
+
+  var countryIds = [];
+  if (args.country) {
+    var parts = args.country.split(',');
+    for (var i = 0; i < parts.length; i++) {
+      var key = parts[i].trim().toLowerCase();
+      if (countryMap[key]) countryIds.push(countryMap[key]);
+    }
+  }
+
+  var allResults = [];
+  var limitFrom = 0;
+  var maxPages = 10;
+
+  for (var page = 0; page < maxPages; page++) {
+    var formData = new URLSearchParams();
+    formData.append('dateFrom', from);
+    formData.append('dateTo', to);
+    formData.append('limit_from', String(limitFrom));
+    for (var c = 0; c < countryIds.length; c++) {
+      formData.append('country[]', countryIds[c]);
+    }
+    if (page > 0 && allResults.length > 0) {
+      formData.append('last_time_scope', String(allResults._lastTimeScope || ''));
+    }
+
+    var resp = await fetch('https://www.investing.com/earnings-calendar/Service/getCalendarFilteredData', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      body: formData.toString(),
+      credentials: 'include'
+    });
+    if (!resp.ok) return {error: 'HTTP ' + resp.status};
+    var data = await resp.json();
+
+    // Parse HTML table rows
+    var parser = new DOMParser();
+    var doc = parser.parseFromString('<table>' + data.data + '</table>', 'text/html');
+    var rows = doc.querySelectorAll('tr');
+
+    var currentDate = '';
+    for (var r = 0; r < rows.length; r++) {
+      var row = rows[r];
+
+      // Date divider
+      if (row.hasAttribute('tablesorterdivider')) {
+        var dayCell = row.querySelector('.theDay');
+        if (dayCell) currentDate = dayCell.textContent.trim();
+        continue;
+      }
+
+      var companyCell = row.querySelector('.earnCalCompanyName');
+      if (!companyCell) continue;
+
+      var tds = row.querySelectorAll('td');
+      var flag = row.querySelector('.ceFlags');
+      var link = row.querySelector('a.bold');
+      var pairEl = row.querySelector('[_p_pid]');
+      var timeSpan = tds.length >= 8 ? tds[7].querySelector('span') : null;
+
+      var entry = {
+        date: currentDate,
+        country: flag ? flag.getAttribute('title') : '',
+        name: companyCell.textContent.trim(),
+        symbol: link ? link.textContent.trim() : '',
+        pairId: pairEl ? pairEl.getAttribute('_p_pid') : '',
+        url: link ? 'https://www.investing.com' + link.getAttribute('href') : ''
+      };
+
+      if (tds.length >= 8) {
+        var epsActual = tds[2] ? tds[2].textContent.trim() : '';
+        var epsForecast = tds[3] ? tds[3].textContent.trim().replace(/^\/\s*/, '').trim() : '';
+        var revActual = tds[4] ? tds[4].textContent.trim() : '';
+        var revForecast = tds[5] ? tds[5].textContent.trim().replace(/^\/\s*/, '').trim() : '';
+        var marketCap = tds[6] ? tds[6].textContent.trim() : '';
+        var time = timeSpan ? (timeSpan.getAttribute('data-tooltip') || '') : '';
+
+        entry.eps_actual = epsActual !== '--' ? epsActual : null;
+        entry.eps_forecast = epsForecast !== '--' ? epsForecast : null;
+        entry.revenue_actual = revActual !== '--' ? revActual : null;
+        entry.revenue_forecast = revForecast !== '--' ? revForecast : null;
+        entry.market_cap = marketCap;
+        entry.time = time || null;
+      }
+
+      allResults.push(entry);
+    }
+
+    allResults._lastTimeScope = data.last_time_scope;
+
+    // No more pages
+    if (!data.bind_scroll_handler) break;
+    limitFrom = 1;
+  }
+
+  // Clean up internal property
+  delete allResults._lastTimeScope;
+
+  // Group by date
+  var byDate = {};
+  for (var j = 0; j < allResults.length; j++) {
+    var d = allResults[j].date;
+    if (!byDate[d]) byDate[d] = [];
+    byDate[d].push(allResults[j]);
+  }
+
+  return {
+    from: from,
+    to: to,
+    total: allResults.length,
+    dates: Object.keys(byDate),
+    earnings: byDate
+  };
+}

--- a/investing/gainers.js
+++ b/investing/gainers.js
@@ -1,0 +1,32 @@
+/* @meta
+{
+  "name": "investing/gainers",
+  "description": "Get top gaining US stocks",
+  "domain": "www.investing.com",
+  "args": {},
+  "capabilities": ["network"],
+  "readOnly": true,
+  "example": "bb-browser site investing/gainers"
+}
+*/
+
+async function(args) {
+  const resp = await fetch('https://api.investing.com/api/financialdata/table/domain/gainersStocks?fieldmap=stocks.marketMoversUS&filter-domain=www');
+  if (!resp.ok) return {error: 'HTTP ' + resp.status};
+  const data = await resp.json();
+  if (data['@errors']) return {error: data['@errors'].join('; ')};
+
+  return {
+    count: data.data?.length || 0,
+    stocks: (data.data || []).map(d => ({
+      id: parseInt(d.pair),
+      symbol: d.symbol,
+      name: d.name,
+      price: parseFloat(d.data?.[1]),
+      change_pct: parseFloat(d.data?.[2]),
+      volume: parseInt(d.volume),
+      exchange: d.exchange_symbol,
+      url: 'https://www.investing.com' + d.url
+    }))
+  };
+}

--- a/investing/history.js
+++ b/investing/history.js
@@ -1,0 +1,48 @@
+/* @meta
+{
+  "name": "investing/history",
+  "description": "Get historical price data table with formatted OHLCV and change percentage",
+  "domain": "www.investing.com",
+  "args": {
+    "id": {"required": true, "description": "Instrument ID (use investing/search to find it)"},
+    "from": {"required": false, "description": "Start date YYYY-MM-DD (default: 30 days ago)"},
+    "to": {"required": false, "description": "End date YYYY-MM-DD (default: today)"},
+    "timeframe": {"required": false, "description": "Daily/Weekly/Monthly (default: Daily)"}
+  },
+  "capabilities": ["network"],
+  "readOnly": true,
+  "example": "bb-browser site investing/history 6408 --from 2026-01-01"
+}
+*/
+
+async function(args) {
+  if (!args.id) return {error: 'Missing argument: id'};
+
+  const to = args.to || new Date().toISOString().slice(0, 10);
+  const from = args.from || new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
+  const timeframe = args.timeframe || 'Daily';
+
+  const url = 'https://api.investing.com/api/financialdata/historical/' + args.id +
+    '?start-date=' + from + '&end-date=' + to +
+    '&time-frame=' + timeframe + '&add-missing-rows=false';
+
+  const resp = await fetch(url, {headers: {'domain-id': 'www'}});
+  if (!resp.ok) return {error: 'HTTP ' + resp.status};
+  const data = await resp.json();
+  if (data['@errors']) return {error: data['@errors'].join('; ')};
+
+  return {
+    instrument_id: parseInt(args.id),
+    from: from, to: to, timeframe: timeframe,
+    count: data.data?.length || 0,
+    data: (data.data || []).map(d => ({
+      date: d.rowDate,
+      open: parseFloat(d.last_openRaw),
+      high: parseFloat(d.last_maxRaw),
+      low: parseFloat(d.last_minRaw),
+      close: parseFloat(d.last_closeRaw),
+      volume: d.volumeRaw,
+      change_pct: d.change_precentRaw
+    }))
+  };
+}

--- a/investing/losers.js
+++ b/investing/losers.js
@@ -1,0 +1,32 @@
+/* @meta
+{
+  "name": "investing/losers",
+  "description": "Get top losing US stocks",
+  "domain": "www.investing.com",
+  "args": {},
+  "capabilities": ["network"],
+  "readOnly": true,
+  "example": "bb-browser site investing/losers"
+}
+*/
+
+async function(args) {
+  const resp = await fetch('https://api.investing.com/api/financialdata/table/domain/losersStocks?fieldmap=stocks.marketMoversUS&filter-domain=www');
+  if (!resp.ok) return {error: 'HTTP ' + resp.status};
+  const data = await resp.json();
+  if (data['@errors']) return {error: data['@errors'].join('; ')};
+
+  return {
+    count: data.data?.length || 0,
+    stocks: (data.data || []).map(d => ({
+      id: parseInt(d.pair),
+      symbol: d.symbol,
+      name: d.name,
+      price: parseFloat(d.data?.[1]),
+      change_pct: parseFloat(d.data?.[2]),
+      volume: parseInt(d.volume),
+      exchange: d.exchange_symbol,
+      url: 'https://www.investing.com' + d.url
+    }))
+  };
+}

--- a/investing/revenue.js
+++ b/investing/revenue.js
@@ -1,0 +1,43 @@
+/* @meta
+{
+  "name": "investing/revenue",
+  "description": "Get revenue and net income chart data for a stock",
+  "domain": "www.investing.com",
+  "args": {
+    "id": {"required": true, "description": "Instrument ID (use investing/search to find it)"},
+    "period": {"required": false, "description": "Annual or Quarterly (default: Annual)"},
+    "points": {"required": false, "description": "Number of periods (default: 8)"}
+  },
+  "capabilities": ["network"],
+  "readOnly": true,
+  "example": "bb-browser site investing/revenue 6408"
+}
+*/
+
+async function(args) {
+  if (!args.id) return {error: 'Missing argument: id'};
+  const period = args.period || 'Annual';
+  const points = parseInt(args.points) || 8;
+
+  const url = 'https://api.investing.com/api/financialdata/revenue/chart/?instrumentid=' +
+    args.id + '&period=' + period + '&pointscount=' + points;
+  const resp = await fetch(url);
+  if (!resp.ok) return {error: 'HTTP ' + resp.status};
+  const data = await resp.json();
+  if (data['@errors']) return {error: data['@errors'].join('; ')};
+
+  const chart = data.chart_data || {};
+  const intervals = chart.interval || [];
+  const revenue = chart.datasets?.one || [];
+  const netIncome = chart.datasets?.two || [];
+
+  return {
+    instrument_id: parseInt(args.id),
+    period: period,
+    data: intervals.map((ts, i) => ({
+      date: new Date(ts).toISOString().slice(0, 10),
+      revenue: revenue[i] || 0,
+      net_income: netIncome[i] || 0
+    }))
+  };
+}

--- a/investing/search.js
+++ b/investing/search.js
@@ -1,0 +1,36 @@
+/* @meta
+{
+  "name": "investing/search",
+  "description": "Search financial instruments (stocks, indices, forex, crypto, commodities, ETFs)",
+  "domain": "www.investing.com",
+  "args": {
+    "query": {"required": true, "description": "Search query (e.g. 'AAPL', 'bitcoin', 'S&P 500')"}
+  },
+  "capabilities": ["network"],
+  "readOnly": true,
+  "example": "bb-browser site investing/search AAPL"
+}
+*/
+
+async function(args) {
+  if (!args.query) return {error: 'Missing argument: query'};
+  const resp = await fetch('https://api.investing.com/api/search/v2/search?q=' + encodeURIComponent(args.query));
+  if (!resp.ok) return {error: 'HTTP ' + resp.status};
+  const data = await resp.json();
+
+  return {
+    quotes: (data.quotes || []).map(q => ({
+      id: q.id, symbol: q.symbol, name: q.description,
+      exchange: q.exchange, type: q.type, flag: q.flag,
+      url: 'https://www.investing.com' + q.url
+    })),
+    news: (data.news || []).slice(0, 5).map(n => ({
+      id: n.id, title: n.description,
+      url: 'https://www.investing.com' + n.url
+    })),
+    articles: (data.articles || []).slice(0, 5).map(a => ({
+      id: a.id, title: a.description,
+      url: 'https://www.investing.com' + a.url
+    }))
+  };
+}


### PR DESCRIPTION
Add 7 investing.com site adapters. Key fix: earnings adapter uses legacy XHR endpoint to reliably load Thu/Fri data that the new Next.js SSR page cannot serve.