### PR TITLE
fix(twitter): read user screen name from core fields

### DIFF
--- a/twitter/user.js
+++ b/twitter/user.js
@@ -33,7 +33,9 @@ async function(args) {
   const u = d.data?.user?.result;
   if (!u) return {error: 'User not found', hint: 'Check spelling: @' + args.screen_name};
   const l = u.legacy || {};
-  return {id: u.rest_id, name: l.name, screen_name: l.screen_name, bio: l.description,
-    url: 'https://x.com/' + l.screen_name,
+  const screenName = l.screen_name || u.core?.screen_name || args.screen_name;
+  const name = l.name || u.core?.name;
+  return {id: u.rest_id, name, screen_name: screenName, bio: l.description,
+    url: 'https://x.com/' + screenName,
     followers: l.followers_count, following: l.friends_count, tweets: l.statuses_count, verified: u.is_blue_verified};
 }


### PR DESCRIPTION
## Summary
- fall back to Twitter/X user core fields when legacy name or screen_name is absent
- keep the returned profile URL from becoming https://x.com/undefined

## Test
- bb-browser site twitter/user OpenAI --json