### PR TITLE
feat(twitter): expose engagement metrics

### DIFF
--- a/twitter/search.js
+++ b/twitter/search.js
@@ -90,10 +90,14 @@ async function(args) {
       const u = tw.core?.user_results?.result;
       const nt = tw.note_tweet?.note_tweet_results?.result?.text;
       const screenName = u?.legacy?.screen_name || u?.core?.screen_name;
+      const rawViewCount = tw.views?.count;
+      const viewCount = rawViewCount == null ? null : Number(rawViewCount);
       tweets.push({id: tw.rest_id, author: screenName,
         name: u?.legacy?.name || u?.core?.name,
         url: 'https://x.com/' + (screenName || '_') + '/status/' + tw.rest_id,
         text: nt || l.full_text || '', likes: l.favorite_count, retweets: l.retweet_count,
+        replies: l.reply_count ?? null, bookmarks: l.bookmark_count ?? null,
+        views: Number.isFinite(viewCount) ? viewCount : null,
         in_reply_to: l.in_reply_to_status_id_str || undefined, created_at: l.created_at});
     }
   }

--- a/twitter/thread.js
+++ b/twitter/thread.js
@@ -43,9 +43,14 @@ async function(args) {
     const u = tw.core?.user_results?.result;
     const nt = tw.note_tweet?.note_tweet_results?.result?.text;
     const screenName = u?.legacy?.screen_name || u?.core?.screen_name;
+    const rawViewCount = tw.views?.count;
+    const viewCount = rawViewCount == null ? null : Number(rawViewCount);
     tweets.push({id: tw.rest_id, author: screenName, text: nt || l.full_text || '',
       url: 'https://x.com/' + (screenName || '_') + '/status/' + tw.rest_id,
-      likes: l.favorite_count, retweets: l.retweet_count, in_reply_to: l.in_reply_to_status_id_str, created_at: l.created_at});
+      likes: l.favorite_count, retweets: l.retweet_count,
+      replies: l.reply_count ?? null, bookmarks: l.bookmark_count ?? null,
+      views: Number.isFinite(viewCount) ? viewCount : null,
+      in_reply_to: l.in_reply_to_status_id_str, created_at: l.created_at});
   }
 
   for (let page = 0; page < maxPages; page++) {


### PR DESCRIPTION
## Summary

- add reply and bookmark counts to Twitter search and thread results
- parse Twitter view counts into stable numeric values
- return `null` when an engagement metric is absent instead of omitting the key

## Validation

- parsed both adapter files with `new Function`
- reviewed against Twitter GraphQL tweet result fields

Related: leeguooooo/chrome-use#124