### PR TITLE
feat(stage3): add HN and Reddit envelope pilots

### DIFF
--- a/fixtures/hackernews/thread.json
+++ b/fixtures/hackernews/thread.json
@@ -81,6 +81,17 @@
       "type": "story",
       "dead": true,
       "kids": []
+    },
+    "1234567890123456": {
+      "id": 1234567890123456,
+      "type": "story",
+      "title": "Long numeric string story",
+      "url": "https://example.com/long-id",
+      "by": "longid",
+      "score": 1,
+      "descendants": 0,
+      "time": 1700000700,
+      "kids": []
     }
   }
 }

--- a/fixtures/hackernews/thread.json
+++ b/fixtures/hackernews/thread.json
@@ -43,6 +43,44 @@
       "by": "deep",
       "text": "Depth-limited reply",
       "time": 1700000300
+    },
+    "210": {
+      "id": 210,
+      "type": "story",
+      "title": "Complete nested story",
+      "url": "https://example.com/complete",
+      "by": "submitter",
+      "score": 50,
+      "descendants": 2,
+      "time": 1700000400,
+      "kids": [211]
+    },
+    "211": {
+      "id": 211,
+      "type": "comment",
+      "by": "top",
+      "text": "Top-level visible",
+      "time": 1700000500,
+      "kids": [212]
+    },
+    "212": {
+      "id": 212,
+      "type": "comment",
+      "by": "nested",
+      "text": "Nested visible",
+      "time": 1700000600
+    },
+    "220": {
+      "id": 220,
+      "type": "story",
+      "deleted": true,
+      "kids": []
+    },
+    "221": {
+      "id": 221,
+      "type": "story",
+      "dead": true,
+      "kids": []
     }
   }
 }

--- a/fixtures/hackernews/thread.json
+++ b/fixtures/hackernews/thread.json
@@ -1,0 +1,48 @@
+{
+  "items": {
+    "200": {
+      "id": 200,
+      "type": "story",
+      "title": "Thread story",
+      "url": "https://example.com/thread",
+      "by": "submitter",
+      "score": 100,
+      "descendants": 4,
+      "time": 1700000000,
+      "kids": [201, 202, 203]
+    },
+    "201": {
+      "id": 201,
+      "type": "comment",
+      "by": "commenter",
+      "text": "Visible comment",
+      "time": 1700000100,
+      "kids": [204]
+    },
+    "202": {
+      "id": 202,
+      "type": "comment",
+      "deleted": true
+    },
+    "203": {
+      "id": 203,
+      "type": "comment",
+      "dead": true
+    },
+    "204": {
+      "id": 204,
+      "type": "comment",
+      "by": "reply",
+      "text": "Nested reply",
+      "time": 1700000200,
+      "kids": [205]
+    },
+    "205": {
+      "id": 205,
+      "type": "comment",
+      "by": "deep",
+      "text": "Depth-limited reply",
+      "time": 1700000300
+    }
+  }
+}

--- a/fixtures/hackernews/top.json
+++ b/fixtures/hackernews/top.json
@@ -1,0 +1,38 @@
+{
+  "normal": {
+    "ids": [101, 102, 103],
+    "items": {
+      "101": {
+        "id": 101,
+        "type": "story",
+        "title": "First HN story",
+        "url": "https://example.com/first",
+        "by": "alice",
+        "score": 42,
+        "descendants": 7
+      },
+      "102": {
+        "id": 102,
+        "type": "story",
+        "title": "Second HN story",
+        "url": null,
+        "by": "bob",
+        "score": 11,
+        "descendants": 0
+      },
+      "103": {
+        "id": 103,
+        "type": "story",
+        "title": "Third HN story",
+        "url": "https://example.com/third",
+        "by": "carol",
+        "score": 5,
+        "descendants": 1
+      }
+    }
+  },
+  "empty": {
+    "ids": [],
+    "items": {}
+  }
+}

--- a/fixtures/hackernews/top.json
+++ b/fixtures/hackernews/top.json
@@ -34,5 +34,34 @@
   "empty": {
     "ids": [],
     "items": {}
+  },
+  "selected_omissions": {
+    "ids": [301, 302, 303, 304, 305],
+    "items": {
+      "301": {
+        "id": 301,
+        "type": "story",
+        "title": "Only valid selected story",
+        "url": "https://example.com/valid",
+        "by": "valid",
+        "score": 9,
+        "descendants": 2
+      },
+      "302": {
+        "id": 302,
+        "type": "story",
+        "deleted": true
+      },
+      "303": {
+        "id": 303,
+        "type": "story",
+        "dead": true
+      },
+      "304": {
+        "id": 304,
+        "type": "comment",
+        "text": "Not a story"
+      }
+    }
   }
 }

--- a/fixtures/reddit/search.json
+++ b/fixtures/reddit/search.json
@@ -1,0 +1,34 @@
+{
+  "normal": {
+    "kind": "Listing",
+    "data": {
+      "after": "t3_after",
+      "children": [
+        {
+          "kind": "t3",
+          "data": {
+            "name": "t3_a",
+            "title": "First Reddit post",
+            "author": "alice",
+            "subreddit_name_prefixed": "r/AI_Agents",
+            "score": 12,
+            "num_comments": 3,
+            "created_utc": 1700000000,
+            "url": "https://example.com/a",
+            "permalink": "/r/AI_Agents/comments/a/first/",
+            "selftext": "Self text preview for first result",
+            "is_self": true,
+            "link_flair_text": "Discussion"
+          }
+        }
+      ]
+    }
+  },
+  "empty": {
+    "kind": "Listing",
+    "data": {
+      "after": null,
+      "children": []
+    }
+  }
+}

--- a/fixtures/reddit/thread.json
+++ b/fixtures/reddit/thread.json
@@ -1,0 +1,88 @@
+{
+  "normal": [
+    {
+      "kind": "Listing",
+      "data": {
+        "children": [
+          {
+            "kind": "t3",
+            "data": {
+              "name": "t3_post",
+              "title": "Reddit thread",
+              "author": "poster",
+              "subreddit_name_prefixed": "r/AI_Agents",
+              "score": 55,
+              "num_comments": 4,
+              "selftext": "Post body",
+              "url": "https://example.com/post",
+              "created_utc": 1700000000
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "Listing",
+      "data": {
+        "children": [
+          {
+            "kind": "t1",
+            "data": {
+              "name": "t1_a",
+              "parent_id": "t3_post",
+              "author": "alice",
+              "score": 9,
+              "body": "Top-level comment",
+              "replies": {
+                "kind": "Listing",
+                "data": {
+                  "children": [
+                    {
+                      "kind": "t1",
+                      "data": {
+                        "name": "t1_b",
+                        "parent_id": "t1_a",
+                        "author": "bob",
+                        "score": 4,
+                        "body": "Nested comment",
+                        "replies": {
+                          "kind": "Listing",
+                          "data": {
+                            "children": [
+                              {
+                                "kind": "t1",
+                                "data": {
+                                  "name": "t1_c",
+                                  "parent_id": "t1_b",
+                                  "author": "carol",
+                                  "score": 1,
+                                  "body": "Depth-limited comment"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "more",
+            "data": {
+              "children": ["t1_more_a", "t1_more_b"]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "empty": [
+    {
+      "kind": "Listing",
+      "data": {"children": []}
+    }
+  ]
+}

--- a/hackernews/site.json
+++ b/hackernews/site.json
@@ -1,0 +1,51 @@
+{
+  "name": "hackernews",
+  "description": "Hacker News read-only adapters",
+  "domain": "news.ycombinator.com",
+  "version": "0.1.0",
+  "commands": {
+    "top": {
+      "description": "Fetch current Hacker News top stories",
+      "auth": "none",
+      "profile": "not_applicable",
+      "side_effect": "read_only",
+      "retry_safety": "safe_with_backoff",
+      "max_concurrency": 4,
+      "serialization_key": "site:hackernews",
+      "output_modes": ["legacy", "envelope_v1"],
+      "timeout_class": "standard",
+      "envelope_versions": ["pinix.site-result-envelope.v1"],
+      "params": {
+        "count": {
+          "type": "number",
+          "required": false,
+          "description": "Number of stories (default: 20, max: 50)"
+        }
+      }
+    },
+    "thread": {
+      "description": "Fetch a Hacker News story and bounded comment tree",
+      "auth": "none",
+      "profile": "not_applicable",
+      "side_effect": "read_only",
+      "retry_safety": "safe_with_backoff",
+      "max_concurrency": 4,
+      "serialization_key": "site:hackernews",
+      "output_modes": ["legacy", "envelope_v1"],
+      "timeout_class": "standard",
+      "envelope_versions": ["pinix.site-result-envelope.v1"],
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true,
+          "description": "HN item ID or item URL"
+        },
+        "depth": {
+          "type": "number",
+          "required": false,
+          "description": "Comment tree depth (default: 2, max: 5)"
+        }
+      }
+    }
+  }
+}

--- a/hackernews/thread.js
+++ b/hackernews/thread.js
@@ -4,8 +4,22 @@
   "description": "获取 Hacker News 帖子的评论树",
   "domain": "news.ycombinator.com",
   "args": {
-    "id": {"required": true, "description": "HN item ID or URL"}
+    "id": {"required": true, "description": "HN item ID or URL"},
+    "depth": {"required": false, "description": "Comment tree depth (default: 2, max: 5)"}
   },
+  "params": {
+    "id": {"type": "string", "required": true, "description": "HN item ID or URL"},
+    "depth": {"type": "number", "required": false, "description": "Comment tree depth (default: 2, max: 5)"}
+  },
+  "auth": "none",
+  "profile": "not_applicable",
+  "side_effect": "read_only",
+  "retry_safety": "safe_with_backoff",
+  "max_concurrency": 4,
+  "serialization_key": "site:hackernews",
+  "output_modes": ["legacy", "envelope_v1"],
+  "timeout_class": "standard",
+  "envelope_versions": ["pinix.site-result-envelope.v1"],
   "capabilities": ["network"],
   "readOnly": true,
   "example": "bb-browser site hackernews/thread 12345678"
@@ -13,23 +27,35 @@
 */
 
 async function(args) {
-  if (!args.id) return {error: 'Missing argument: id'};
+  if (!args.id) return {error: 'Missing argument: id', hint: 'Provide an HN item ID or item URL'};
   let itemId = args.id;
   const urlMatch = itemId.match(/id=(\d+)/);
   if (urlMatch) itemId = urlMatch[1];
+  const parsedDepth = parseInt(args.depth);
+  const depthLimit = Math.min(Math.max(Number.isFinite(parsedDepth) ? parsedDepth : 2, 0), 5);
+  const stats = {deleted_dead: 0, depth_truncated: 0, child_limit_truncated: 0};
 
-  const resp = await fetch('https://hacker-news.firebaseio.com/v0/item/' + itemId + '.json');
+  const itemUrl = 'https://hacker-news.firebaseio.com/v0/item/' + itemId + '.json';
+  const resp = await fetch(itemUrl);
   if (!resp.ok) return {error: 'HTTP ' + resp.status};
   const item = await resp.json();
   if (!item) return {error: 'Item not found', hint: 'Check the ID: ' + itemId};
 
-  // Fetch comment tree (max 2 levels deep for performance)
+  // Fetch comment tree with bounded depth and fanout for performance.
   async function fetchComments(ids, depth) {
-    if (!ids || ids.length === 0 || depth > 2) return [];
+    if (!ids || ids.length === 0) return [];
+    if (depth > depthLimit) {
+      stats.depth_truncated += ids.length;
+      return [];
+    }
+    if (ids.length > 30) stats.child_limit_truncated += ids.length - 30;
     const comments = await Promise.all(ids.slice(0, 30).map(async id => {
       const r = await fetch('https://hacker-news.firebaseio.com/v0/item/' + id + '.json');
       const c = await r.json();
-      if (!c || c.deleted || c.dead) return null;
+      if (!c || c.deleted || c.dead) {
+        stats.deleted_dead += 1;
+        return null;
+      }
       return {
         id: c.id, author: c.by, text: c.text, time: c.time, depth,
         replies: await fetchComments(c.kids, depth + 1)
@@ -39,8 +65,31 @@ async function(args) {
   }
 
   const comments = await fetchComments(item.kids, 0);
-  return {
+  const data = {
     post: {id: item.id, title: item.title, url: item.url || null, hn_url: 'https://news.ycombinator.com/item?id=' + item.id, author: item.by, score: item.score, comments_count: item.descendants || 0, time: item.time, text: item.text},
     comments
+  };
+  const partial = stats.deleted_dead > 0 || stats.depth_truncated > 0 || stats.child_limit_truncated > 0;
+
+  return {
+    __pinix_site_result: {
+      version: 'pinix.site-adapter-result.v1',
+      metadata: {
+        effective_args: {id: String(itemId), depth: depthLimit},
+        completeness: partial ? 'partial' : 'complete',
+        reason: partial ? 'comments_omitted' : 'complete',
+        source: {url: itemUrl},
+        pagination: {
+          depth: depthLimit,
+          comments_returned: comments.length,
+          deleted_dead_omitted: stats.deleted_dead,
+          depth_truncated: stats.depth_truncated,
+          child_limit_truncated: stats.child_limit_truncated
+        },
+        auth: {authenticated_as: 'not_applicable'},
+        warnings: partial ? [{code: 'PARTIAL_COMMENTS', message: 'Some comments were omitted because they were deleted/dead or beyond adapter depth/fanout limits.'}] : undefined
+      }
+    },
+    data
   };
 }

--- a/hackernews/thread.js
+++ b/hackernews/thread.js
@@ -40,6 +40,7 @@ async function(args) {
   if (!resp.ok) return {error: 'HTTP ' + resp.status};
   const item = await resp.json();
   if (!item) return {error: 'Item not found', hint: 'Check the ID: ' + itemId};
+  const rootUnavailable = !!(item.deleted || item.dead);
 
   // Fetch comment tree with bounded depth and fanout for performance.
   async function fetchComments(ids, depth) {
@@ -65,11 +66,16 @@ async function(args) {
   }
 
   const comments = await fetchComments(item.kids, 0);
+  function countComments(nodes) {
+    return nodes.reduce((total, node) => total + 1 + countComments(node.replies || []), 0);
+  }
+  const commentsReturned = countComments(comments);
   const data = {
     post: {id: item.id, title: item.title, url: item.url || null, hn_url: 'https://news.ycombinator.com/item?id=' + item.id, author: item.by, score: item.score, comments_count: item.descendants || 0, time: item.time, text: item.text},
     comments
   };
-  const partial = stats.deleted_dead > 0 || stats.depth_truncated > 0 || stats.child_limit_truncated > 0;
+  const partial = rootUnavailable || stats.deleted_dead > 0 || stats.depth_truncated > 0 || stats.child_limit_truncated > 0;
+  const reason = rootUnavailable ? 'root_unavailable' : (partial ? 'comments_omitted' : 'complete');
 
   return {
     __pinix_site_result: {
@@ -77,17 +83,22 @@ async function(args) {
       metadata: {
         effective_args: {id: String(itemId), depth: depthLimit},
         completeness: partial ? 'partial' : 'complete',
-        reason: partial ? 'comments_omitted' : 'complete',
+        reason,
         source: {url: itemUrl},
         pagination: {
           depth: depthLimit,
-          comments_returned: comments.length,
+          comments_returned: commentsReturned,
+          top_level_comments_returned: comments.length,
+          root_deleted: item.deleted ? 1 : 0,
+          root_dead: item.dead ? 1 : 0,
           deleted_dead_omitted: stats.deleted_dead,
           depth_truncated: stats.depth_truncated,
           child_limit_truncated: stats.child_limit_truncated
         },
         auth: {authenticated_as: 'not_applicable'},
-        warnings: partial ? [{code: 'PARTIAL_COMMENTS', message: 'Some comments were omitted because they were deleted/dead or beyond adapter depth/fanout limits.'}] : undefined
+        warnings: rootUnavailable
+          ? [{code: 'ROOT_UNAVAILABLE', message: 'The root HN item is deleted or dead; legacy data is preserved but completeness is partial.'}]
+          : (partial ? [{code: 'PARTIAL_COMMENTS', message: 'Some comments were omitted because they were deleted/dead or beyond adapter depth/fanout limits.'}] : undefined)
       }
     },
     data

--- a/hackernews/thread.js
+++ b/hackernews/thread.js
@@ -27,8 +27,8 @@
 */
 
 async function(args) {
-  if (!args.id) return {error: 'Missing argument: id', hint: 'Provide an HN item ID or item URL'};
-  let itemId = args.id;
+  if (args.id === undefined || args.id === null || args.id === '') return {error: 'Missing argument: id', hint: 'Provide an HN item ID or item URL'};
+  let itemId = String(args.id);
   const urlMatch = itemId.match(/id=(\d+)/);
   if (urlMatch) itemId = urlMatch[1];
   const parsedDepth = parseInt(args.depth);

--- a/hackernews/top.js
+++ b/hackernews/top.js
@@ -41,8 +41,24 @@ async function(args) {
     return await itemResp.json();
   }));
 
+  const stats = {fetch_missing: 0, deleted_dead: 0, non_story: 0, missing_title: 0};
   const posts = items.map((item, i) => {
-    if (!item || item.deleted || item.dead || item.type !== 'story') return null;
+    if (!item) {
+      stats.fetch_missing += 1;
+      return null;
+    }
+    if (item.deleted || item.dead) {
+      stats.deleted_dead += 1;
+      return null;
+    }
+    if (item.type !== 'story') {
+      stats.non_story += 1;
+      return null;
+    }
+    if (!item.id || !item.title) {
+      stats.missing_title += 1;
+      return null;
+    }
     return {
       rank: i + 1,
       id: item.id,
@@ -53,14 +69,20 @@ async function(args) {
       score: item.score || 0,
       comments: item.descendants || 0
     };
-  }).filter(item => item && item.id && item.title);
+  }).filter(Boolean);
 
   const data = {
     count: posts.length,
     posts
   };
   const truncated = ids.length > count;
-  const completeness = posts.length === 0 ? 'empty' : (truncated ? 'partial' : 'complete');
+  const selectedOmitted = stats.fetch_missing + stats.deleted_dead + stats.non_story + stats.missing_title;
+  const completeness = ids.length === 0 ? 'empty' : ((truncated || selectedOmitted > 0) ? 'partial' : 'complete');
+  const reason = ids.length === 0 ? 'no_items' : (
+    truncated && selectedOmitted > 0 ? 'limit_truncated_and_selected_items_omitted' :
+    selectedOmitted > 0 ? 'selected_items_omitted' :
+    truncated ? 'limit_truncated' : 'complete'
+  );
 
   return {
     __pinix_site_result: {
@@ -68,15 +90,22 @@ async function(args) {
       metadata: {
         effective_args: {count},
         completeness,
-        reason: posts.length === 0 ? 'no_items' : (truncated ? 'limit_truncated' : 'complete'),
+        reason,
         source: {url: topUrl},
         pagination: {
           limit: count,
+          selected: selected.length,
           returned: posts.length,
           total_available: ids.length,
-          truncated
+          truncated,
+          selected_omitted: selectedOmitted,
+          fetch_missing_omitted: stats.fetch_missing,
+          deleted_dead_omitted: stats.deleted_dead,
+          non_story_omitted: stats.non_story,
+          missing_title_omitted: stats.missing_title
         },
-        auth: {authenticated_as: 'not_applicable'}
+        auth: {authenticated_as: 'not_applicable'},
+        warnings: selectedOmitted > 0 ? [{code: 'SELECTED_ITEMS_OMITTED', message: 'Some selected topstories items were missing, deleted/dead, non-story, or lacked a title.'}] : undefined
       }
     },
     data

--- a/hackernews/top.js
+++ b/hackernews/top.js
@@ -6,47 +6,79 @@
   "args": {
     "count": {"required": false, "description": "Number of posts (default: 20, max: 50)"}
   },
+  "params": {
+    "count": {"type": "number", "required": false, "description": "Number of posts (default: 20, max: 50)"}
+  },
+  "auth": "none",
+  "profile": "not_applicable",
+  "side_effect": "read_only",
+  "retry_safety": "safe_with_backoff",
+  "max_concurrency": 4,
+  "serialization_key": "site:hackernews",
+  "output_modes": ["legacy", "envelope_v1"],
+  "timeout_class": "standard",
+  "envelope_versions": ["pinix.site-result-envelope.v1"],
   "readOnly": true,
   "example": "bb-browser site hackernews/top 10"
 }
 */
 
 async function(args) {
-  const count = Math.min(parseInt(args.count) || 20, 50);
+  const parsedCount = parseInt(args.count);
+  const count = Math.min(Math.max(Number.isFinite(parsedCount) ? parsedCount : 20, 1), 50);
 
-  // Parse HN homepage HTML instead of cross-origin Firebase API (fixes #8)
-  const resp = await fetch('https://news.ycombinator.com/');
+  const topUrl = 'https://hacker-news.firebaseio.com/v0/topstories.json';
+  const resp = await fetch(topUrl);
   if (!resp.ok) return {error: 'HTTP ' + resp.status};
+  const ids = await resp.json();
+  if (!Array.isArray(ids)) return {error: 'Unexpected response', hint: 'HN Firebase topstories response was not a list'};
 
-  const html = await resp.text();
-  const doc = new DOMParser().parseFromString(html, 'text/html');
-  const rows = Array.from(doc.querySelectorAll('tr.athing')).slice(0, count);
+  const selected = ids.slice(0, count);
+  const items = await Promise.all(selected.map(async id => {
+    const itemUrl = 'https://hacker-news.firebaseio.com/v0/item/' + id + '.json';
+    const itemResp = await fetch(itemUrl);
+    if (!itemResp.ok) return null;
+    return await itemResp.json();
+  }));
 
-  const posts = rows.map((row, i) => {
-    const id = Number(row.getAttribute('id'));
-    const titleLink = row.querySelector('.titleline > a');
-    const subtextRow = row.nextElementSibling;
-    const scoreEl = subtextRow?.querySelector('.score');
-    const authorEl = subtextRow?.querySelector('.hnuser');
-    const links = Array.from(subtextRow?.querySelectorAll('a') || []);
-    const commentsLink = links.find(a => /comment/i.test((a.textContent || '').trim())) || links[links.length - 1];
-    const commentsText = (commentsLink?.textContent || '0').trim();
-    const comments = commentsText === 'discuss' ? 0 : parseInt(commentsText, 10) || 0;
-
+  const posts = items.map((item, i) => {
+    if (!item || item.deleted || item.dead || item.type !== 'story') return null;
     return {
       rank: i + 1,
-      id,
-      title: titleLink?.textContent?.trim() || null,
-      url: titleLink?.href || null,
-      hn_url: 'https://news.ycombinator.com/item?id=' + id,
-      author: authorEl?.textContent?.trim() || null,
-      score: parseInt(scoreEl?.textContent || '0', 10) || 0,
-      comments
+      id: item.id,
+      title: item.title || null,
+      url: item.url || null,
+      hn_url: 'https://news.ycombinator.com/item?id=' + item.id,
+      author: item.by || null,
+      score: item.score || 0,
+      comments: item.descendants || 0
     };
-  }).filter(item => item.id && item.title);
+  }).filter(item => item && item.id && item.title);
 
-  return {
+  const data = {
     count: posts.length,
     posts
+  };
+  const truncated = ids.length > count;
+  const completeness = posts.length === 0 ? 'empty' : (truncated ? 'partial' : 'complete');
+
+  return {
+    __pinix_site_result: {
+      version: 'pinix.site-adapter-result.v1',
+      metadata: {
+        effective_args: {count},
+        completeness,
+        reason: posts.length === 0 ? 'no_items' : (truncated ? 'limit_truncated' : 'complete'),
+        source: {url: topUrl},
+        pagination: {
+          limit: count,
+          returned: posts.length,
+          total_available: ids.length,
+          truncated
+        },
+        auth: {authenticated_as: 'not_applicable'}
+      }
+    },
+    data
   };
 }

--- a/reddit/search.js
+++ b/reddit/search.js
@@ -11,6 +11,23 @@
     "count": {"required": false, "description": "Number of results (default 25, max 100)"},
     "after": {"required": false, "description": "Fullname of the last item for pagination"}
   },
+  "params": {
+    "query": {"type": "string", "required": true, "description": "Search query"},
+    "subreddit": {"type": "string", "required": false, "description": "Limit search to a subreddit (without r/ prefix)"},
+    "sort": {"type": "string", "required": false, "description": "Sort order: relevance (default), hot, top, new, comments"},
+    "time": {"type": "string", "required": false, "description": "Time filter: all (default), hour, day, week, month, year"},
+    "count": {"type": "number", "required": false, "description": "Number of results (default 25, max 100)"},
+    "after": {"type": "string", "required": false, "description": "Fullname of the last item for pagination"}
+  },
+  "auth": "optional",
+  "profile": "required",
+  "side_effect": "read_only",
+  "retry_safety": "safe_with_backoff",
+  "max_concurrency": 1,
+  "serialization_key": "site:reddit:{profile}",
+  "output_modes": ["legacy", "envelope_v1"],
+  "timeout_class": "standard",
+  "envelope_versions": ["pinix.site-result-envelope.v1"],
   "capabilities": ["network"],
   "readOnly": true,
   "example": "bb-browser site reddit/search \"claude code\" --sort top --time week"
@@ -53,7 +70,7 @@ async function(args) {
     link_flair_text: c.data.link_flair_text || null
   }));
 
-  return {
+  const data = {
     query: args.query,
     subreddit: args.subreddit || null,
     sort,
@@ -61,5 +78,32 @@ async function(args) {
     count: posts.length,
     after: d.data.after || null,
     posts
+  };
+  const fullUrl = 'https://www.reddit.com' + url;
+
+  return {
+    __pinix_site_result: {
+      version: 'pinix.site-adapter-result.v1',
+      metadata: {
+        effective_args: {
+          query: args.query,
+          subreddit: args.subreddit || null,
+          sort,
+          time,
+          count,
+          after: args.after || null
+        },
+        completeness: posts.length === 0 ? 'empty' : (d.data.after ? 'partial' : 'complete'),
+        reason: posts.length === 0 ? 'no_results' : (d.data.after ? 'pagination_available' : 'complete'),
+        source: {url: fullUrl},
+        pagination: {
+          limit: count,
+          returned: posts.length,
+          after: d.data.after || null
+        },
+        auth: {authenticated_as: 'unknown'}
+      }
+    },
+    data
   };
 }

--- a/reddit/site.json
+++ b/reddit/site.json
@@ -1,0 +1,117 @@
+{
+  "name": "reddit",
+  "description": "Reddit read-only adapters",
+  "domain": "www.reddit.com",
+  "version": "0.1.0",
+  "commands": {
+    "context": {
+      "description": "Fetch context around a Reddit comment",
+      "auth": "optional",
+      "profile": "required",
+      "side_effect": "read_only",
+      "retry_safety": "safe_with_backoff",
+      "output_modes": ["legacy"],
+      "timeout_class": "standard"
+    },
+    "hot": {
+      "description": "Fetch hot Reddit posts",
+      "auth": "optional",
+      "profile": "required",
+      "side_effect": "read_only",
+      "retry_safety": "safe_with_backoff",
+      "output_modes": ["legacy"],
+      "timeout_class": "standard"
+    },
+    "me": {
+      "description": "Fetch current Reddit user info when logged in",
+      "auth": "optional",
+      "profile": "required",
+      "side_effect": "read_only",
+      "retry_safety": "safe_with_backoff",
+      "output_modes": ["legacy"],
+      "timeout_class": "standard"
+    },
+    "posts": {
+      "description": "Fetch Reddit user posts",
+      "auth": "optional",
+      "profile": "required",
+      "side_effect": "read_only",
+      "retry_safety": "safe_with_backoff",
+      "output_modes": ["legacy"],
+      "timeout_class": "standard"
+    },
+    "search": {
+      "description": "Search Reddit posts",
+      "auth": "optional",
+      "profile": "required",
+      "side_effect": "read_only",
+      "retry_safety": "safe_with_backoff",
+      "max_concurrency": 1,
+      "serialization_key": "site:reddit:{profile}",
+      "output_modes": ["legacy", "envelope_v1"],
+      "timeout_class": "standard",
+      "envelope_versions": ["pinix.site-result-envelope.v1"],
+      "params": {
+        "query": {
+          "type": "string",
+          "required": true,
+          "description": "Search query"
+        },
+        "subreddit": {
+          "type": "string",
+          "required": false,
+          "description": "Limit search to a subreddit without r/ prefix"
+        },
+        "sort": {
+          "type": "string",
+          "required": false,
+          "description": "Sort order: relevance, hot, top, new, comments"
+        },
+        "time": {
+          "type": "string",
+          "required": false,
+          "description": "Time filter: all, hour, day, week, month, year"
+        },
+        "count": {
+          "type": "number",
+          "required": false,
+          "description": "Number of results (default: 25, max: 100)"
+        },
+        "after": {
+          "type": "string",
+          "required": false,
+          "description": "Listing cursor for pagination"
+        }
+      }
+    },
+    "thread": {
+      "description": "Fetch a Reddit post and bounded discussion tree",
+      "auth": "optional",
+      "profile": "required",
+      "side_effect": "read_only",
+      "retry_safety": "safe_with_backoff",
+      "max_concurrency": 1,
+      "serialization_key": "site:reddit:{profile}",
+      "output_modes": ["legacy", "envelope_v1"],
+      "timeout_class": "standard",
+      "envelope_versions": ["pinix.site-result-envelope.v1"],
+      "params": {
+        "url": {
+          "type": "string",
+          "required": true,
+          "description": "Reddit post URL"
+        },
+        "depth": {
+          "type": "number",
+          "required": false,
+          "description": "Comment tree depth (default: 10, max: 10)"
+        },
+        "count": {
+          "type": "number",
+          "required": false,
+          "description": "Comment fetch limit (default: 500, max: 500)"
+        }
+      }
+    }
+  }
+}

--- a/reddit/thread.js
+++ b/reddit/thread.js
@@ -4,8 +4,24 @@
   "description": "获取 Reddit 帖子的完整讨论树",
   "domain": "www.reddit.com",
   "args": {
-    "url": {"required": true, "description": "Reddit post URL"}
+    "url": {"required": true, "description": "Reddit post URL"},
+    "depth": {"required": false, "description": "Comment tree depth (default: 10, max: 10)"},
+    "count": {"required": false, "description": "Comment fetch limit (default: 500, max: 500)"}
   },
+  "params": {
+    "url": {"type": "string", "required": true, "description": "Reddit post URL"},
+    "depth": {"type": "number", "required": false, "description": "Comment tree depth (default: 10, max: 10)"},
+    "count": {"type": "number", "required": false, "description": "Comment fetch limit (default: 500, max: 500)"}
+  },
+  "auth": "optional",
+  "profile": "required",
+  "side_effect": "read_only",
+  "retry_safety": "safe_with_backoff",
+  "max_concurrency": 1,
+  "serialization_key": "site:reddit:{profile}",
+  "output_modes": ["legacy", "envelope_v1"],
+  "timeout_class": "standard",
+  "envelope_versions": ["pinix.site-result-envelope.v1"],
   "capabilities": ["network"],
   "readOnly": true,
   "example": "bb-browser site reddit/thread https://www.reddit.com/r/LocalLLaMA/comments/1rrisqn/..."
@@ -14,34 +30,76 @@
 
 async function(args) {
   if (!args.url) return {error: 'Missing argument: url', hint: 'Provide a Reddit post URL'};
+  const parsedLimit = parseInt(args.count);
+  const parsedDepth = parseInt(args.depth);
+  const limit = Math.min(Math.max(Number.isFinite(parsedLimit) ? parsedLimit : 500, 1), 500);
+  const depthLimit = Math.min(Math.max(Number.isFinite(parsedDepth) ? parsedDepth : 10, 0), 10);
   let path = args.url.replace(/https?:\/\/[^/]*/, '').replace(/\?.*/, '').replace(/\/*$/, '/');
   // Normalize to /r/sub/comments/POST_ID/ — strip slug and any comment suffixes
   // Handles: .../comments/ID/slug/, .../comments/ID/comment/CID/, .../comments/ID/slug/CID/
   const m = path.match(/(\/r\/[^/]+\/comments\/[^/]+\/)/);
   if (m) path = m[1];
-  const resp = await fetch(path + '.json?limit=500&depth=10&raw_json=1', {credentials: 'include'});
+  const canonicalUrl = 'https://www.reddit.com' + path;
+  const apiUrl = path + '.json?limit=' + limit + '&depth=' + depthLimit + '&raw_json=1';
+  const resp = await fetch(apiUrl, {credentials: 'include'});
   if (!resp.ok) return {error: 'HTTP ' + resp.status};
   const d = await resp.json();
   if (!d[0]?.data?.children?.[0]?.data) return {error: 'Unexpected response', hint: 'Post may be deleted or URL is incorrect'};
   const post = d[0].data.children[0].data;
+  const stats = {more: 0, depth_truncated: 0, limit_truncated: 0};
 
   function flatten(children, depth) {
     let result = [];
     for (const child of children) {
+      if (child.kind === 'more') {
+        stats.more += Array.isArray(child.data?.children) ? child.data.children.length : 1;
+        continue;
+      }
       if (child.kind !== 't1') continue;
       const c = child.data;
       result.push({id: c.name, parent_id: c.parent_id, author: c.author, score: c.score, body: c.body, depth});
-      if (c.replies?.data?.children)
+      if (c.replies?.data?.children) {
+        if (depth >= depthLimit) stats.depth_truncated += c.replies.data.children.length;
+        else
         result = result.concat(flatten(c.replies.data.children, depth + 1));
+      }
     }
     return result;
   }
 
-  const comments = flatten(d[1]?.data?.children || [], 0);
-  return {
+  let comments = flatten(d[1]?.data?.children || [], 0);
+  if (comments.length > limit) {
+    stats.limit_truncated = comments.length - limit;
+    comments = comments.slice(0, limit);
+  }
+  const data = {
     post: {id: post.name, title: post.title, author: post.author, subreddit: post.subreddit_name_prefixed,
       score: post.score, num_comments: post.num_comments, selftext: post.selftext, url: post.url, created_utc: post.created_utc},
     comments_total: comments.length,
     comments
+  };
+  const partial = stats.more > 0 || stats.depth_truncated > 0 || stats.limit_truncated > 0;
+
+  return {
+    __pinix_site_result: {
+      version: 'pinix.site-adapter-result.v1',
+      metadata: {
+        effective_args: {url: canonicalUrl, depth: depthLimit, count: limit},
+        completeness: partial ? 'partial' : 'complete',
+        reason: partial ? 'comments_omitted' : 'complete',
+        source: {url: 'https://www.reddit.com' + apiUrl},
+        pagination: {
+          limit,
+          depth: depthLimit,
+          comments_returned: comments.length,
+          more_children_omitted: stats.more,
+          depth_truncated: stats.depth_truncated,
+          limit_truncated: stats.limit_truncated
+        },
+        auth: {authenticated_as: 'unknown'},
+        warnings: partial ? [{code: 'PARTIAL_COMMENTS', message: 'Some comments were omitted because Reddit returned more placeholders or adapter depth/limit was reached.'}] : undefined
+      }
+    },
+    data
   };
 }

--- a/test/stage3-envelope-pilots.test.mjs
+++ b/test/stage3-envelope-pilots.test.mjs
@@ -124,13 +124,35 @@ test("hackernews top returns legacy-shaped data plus carrier metadata", async ()
   assert.equal(env.reason, "limit_truncated");
   assert.deepEqual(env.command.effective_args, { count: 2 });
   assert.equal(env.source.url, "https://hacker-news.firebaseio.com/v0/topstories.json");
-  assert.deepEqual(env.pagination, { limit: 2, returned: 2, total_available: 3, truncated: true });
+  assert.deepEqual(env.pagination, {
+    limit: 2,
+    selected: 2,
+    returned: 2,
+    total_available: 3,
+    truncated: true,
+    selected_omitted: 0,
+    fetch_missing_omitted: 0,
+    deleted_dead_omitted: 0,
+    non_story_omitted: 0,
+    missing_title_omitted: 0
+  });
   assert.deepEqual(env.auth, { requirement: "none", authenticated_as: "not_applicable" });
 });
 
-test("hackernews top covers empty and limit clamp without live fetch", async () => {
+test("hackernews top covers complete, empty and limit clamp without live fetch", async () => {
   const fixture = await loadJSON("../fixtures/hackernews/top.json");
   const manifest = await loadJSON("../hackernews/site.json");
+  const completeAdapter = await loadAdapter("hackernews/top.js", async (url) => {
+    if (url.endsWith("/topstories.json")) return response(fixture.normal.ids);
+    const id = url.match(/item\/(\d+)\.json/)?.[1];
+    return response(fixture.normal.items[id] || null);
+  });
+  const complete = envelopeFor("hackernews", "top", manifest, await completeAdapter({ count: "3" }), { count: "3" });
+  assert.equal(complete.completeness, "complete");
+  assert.equal(complete.reason, "complete");
+  assert.equal(complete.pagination.returned, 3);
+  assert.equal(complete.pagination.selected_omitted, 0);
+
   const emptyAdapter = await loadAdapter("hackernews/top.js", async () => response(fixture.empty.ids));
   const empty = envelopeFor("hackernews", "top", manifest, await emptyAdapter({ count: "5" }), { count: "5" });
   assert.equal(empty.completeness, "empty");
@@ -146,6 +168,28 @@ test("hackernews top covers empty and limit clamp without live fetch", async () 
   assert.equal(env.command.effective_args.count, 50);
   assert.equal(env.pagination.returned, 50);
   assert.equal(env.pagination.truncated, true);
+});
+
+test("hackernews top reports selected fetch/filter omissions as partial", async () => {
+  const fixture = await loadJSON("../fixtures/hackernews/top.json");
+  const manifest = await loadJSON("../hackernews/site.json");
+  const adapter = await loadAdapter("hackernews/top.js", async (url) => {
+    if (url.endsWith("/topstories.json")) return response(fixture.selected_omissions.ids);
+    const id = url.match(/item\/(\d+)\.json/)?.[1];
+    return response(fixture.selected_omissions.items[id] || null);
+  });
+  const env = envelopeFor("hackernews", "top", manifest, await adapter({ count: "5" }), { count: "5" });
+  assert.equal(env.completeness, "partial");
+  assert.equal(env.reason, "selected_items_omitted");
+  assert.equal(env.data.count, 1);
+  assert.equal(env.pagination.returned, 1);
+  assert.equal(env.pagination.selected, 5);
+  assert.equal(env.pagination.selected_omitted, 4);
+  assert.equal(env.pagination.fetch_missing_omitted, 1);
+  assert.equal(env.pagination.deleted_dead_omitted, 2);
+  assert.equal(env.pagination.non_story_omitted, 1);
+  assert.equal(env.pagination.missing_title_omitted, 0);
+  assert.equal(env.warnings.some((warning) => warning.code === "SELECTED_ITEMS_OMITTED"), true);
 });
 
 test("hackernews top covers invalid and network paths without live fetch", async () => {
@@ -166,19 +210,65 @@ test("hackernews thread omits deleted/dead and reports proven partial depth trun
     const id = url.match(/item\/(\d+)\.json/)?.[1];
     return response(fixture.items[id] || null);
   });
-  const result = await adapter({ id: "https://news.ycombinator.com/item?id=200", depth: "0" });
+  const threadArgs = { id: "https://news.ycombinator.com/item?id=200&token=fake#frag", depth: "0" };
+  const result = await adapter(threadArgs);
   const legacy = unwrapSiteAdapterCarrier(result, manifest.commands.thread);
   assert.equal(legacy.post.id, 200);
   assert.equal(legacy.comments.length, 1);
   assert.equal(legacy.comments[0].id, 201);
   assert.deepEqual(plain(legacy.comments[0].replies), []);
 
-  const env = envelopeFor("hackernews", "thread", manifest, result, { id: "https://news.ycombinator.com/item?id=200", depth: "0" });
+  const env = envelopeFor("hackernews", "thread", manifest, result, threadArgs);
   assert.equal(env.completeness, "partial");
   assert.equal(env.reason, "comments_omitted");
+  assert.deepEqual(plain(env.command.requested_args), { id: "https://news.ycombinator.com/item?id=200", depth: "0" });
   assert.deepEqual(env.command.effective_args, { id: "200", depth: 0 });
   assert.equal(env.pagination.deleted_dead_omitted, 2);
   assert.equal(env.pagination.depth_truncated, 1);
+  assert.equal(env.pagination.comments_returned, 1);
+  assert.equal(env.pagination.top_level_comments_returned, 1);
+});
+
+test("hackernews thread counts nested comments recursively", async () => {
+  const fixture = await loadJSON("../fixtures/hackernews/thread.json");
+  const manifest = await loadJSON("../hackernews/site.json");
+  const adapter = await loadAdapter("hackernews/thread.js", async (url) => {
+    const id = url.match(/item\/(\d+)\.json/)?.[1];
+    return response(fixture.items[id] || null);
+  });
+  const env = envelopeFor("hackernews", "thread", manifest, await adapter({ id: "210", depth: "2" }), { id: "210", depth: "2" });
+  assert.equal(env.completeness, "complete");
+  assert.equal(env.pagination.comments_returned, 2);
+  assert.equal(env.pagination.top_level_comments_returned, 1);
+});
+
+test("hackernews thread reports deleted/dead root as non-complete metadata without changing legacy data", async () => {
+  const fixture = await loadJSON("../fixtures/hackernews/thread.json");
+  const manifest = await loadJSON("../hackernews/site.json");
+  const adapter = await loadAdapter("hackernews/thread.js", async (url) => {
+    const id = url.match(/item\/(\d+)\.json/)?.[1];
+    return response(fixture.items[id] || null);
+  });
+
+  const deletedResult = await adapter({ id: "220" });
+  const deletedLegacy = unwrapSiteAdapterCarrier(deletedResult, manifest.commands.thread);
+  const deletedEnv = envelopeFor("hackernews", "thread", manifest, deletedResult, { id: "220" });
+  assert.deepEqual(plain(deletedLegacy), plain(deletedResult.data));
+  assert.equal(deletedEnv.completeness, "partial");
+  assert.equal(deletedEnv.reason, "root_unavailable");
+  assert.equal(deletedEnv.pagination.root_deleted, 1);
+  assert.equal(deletedEnv.pagination.root_dead, 0);
+  assert.equal(deletedEnv.pagination.comments_returned, 0);
+  assert.equal(deletedEnv.warnings.some((warning) => warning.code === "ROOT_UNAVAILABLE"), true);
+
+  const deadResult = await adapter({ id: "221" });
+  const deadEnv = envelopeFor("hackernews", "thread", manifest, deadResult, { id: "221" });
+  assert.equal(deadEnv.completeness, "partial");
+  assert.equal(deadEnv.reason, "root_unavailable");
+  assert.equal(deadEnv.pagination.root_deleted, 0);
+  assert.equal(deadEnv.pagination.root_dead, 1);
+  assert.equal(deadEnv.pagination.comments_returned, 0);
+  assert.equal(deadEnv.warnings.some((warning) => warning.code === "ROOT_UNAVAILABLE"), true);
 });
 
 test("hackernews thread covers invalid and network paths", async () => {

--- a/test/stage3-envelope-pilots.test.mjs
+++ b/test/stage3-envelope-pilots.test.mjs
@@ -1,16 +1,34 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import vm from "node:vm";
 
-import {
+const edgeRepoEnv = process.env.PINIX_EDGE_REPO;
+if (!edgeRepoEnv) {
+  throw new Error("Test setup error: PINIX_EDGE_REPO is required and must point to a pinix-edge checkout/worktree.");
+}
+
+const EDGE_REPO = resolve(edgeRepoEnv);
+const EDGE_SITE_ENVELOPE_PATH = join(EDGE_REPO, "main", "site-envelope.mjs");
+const EDGE_SITE_HANDLER_PATH = join(EDGE_REPO, "main", "handlers", "site.mjs");
+
+try {
+  await access(EDGE_SITE_ENVELOPE_PATH);
+  await access(EDGE_SITE_HANDLER_PATH);
+} catch {
+  throw new Error("Test setup error: PINIX_EDGE_REPO=" + EDGE_REPO + " is not a valid pinix-edge checkout; expected main/site-envelope.mjs and main/handlers/site.mjs.");
+}
+
+const {
   buildSiteResultEnvelope,
   unwrapSiteAdapterCarrier,
   SITE_RESULT_ENVELOPE_VERSION,
-} from "/private/tmp/pinix-edge-170-stage3/main/site-envelope.mjs";
-import {
+} = await import(pathToFileURL(EDGE_SITE_ENVELOPE_PATH).href);
+const {
   buildEnabledSiteIndex,
-} from "/private/tmp/pinix-edge-170-stage3/main/handlers/site.mjs";
+} = await import(pathToFileURL(EDGE_SITE_HANDLER_PATH).href);
 
 async function loadJSON(path) {
   return JSON.parse(await readFile(new URL(path, import.meta.url), "utf8"));
@@ -52,6 +70,9 @@ function plain(value) {
 }
 
 test("manifests expose Stage3 metadata for only the selected pilot commands", async () => {
+  assert.equal(EDGE_SITE_ENVELOPE_PATH.startsWith(EDGE_REPO + "/"), true);
+  assert.equal(EDGE_SITE_HANDLER_PATH.startsWith(EDGE_REPO + "/"), true);
+
   const hn = await loadJSON("../hackernews/site.json");
   const reddit = await loadJSON("../reddit/site.json");
 

--- a/test/stage3-envelope-pilots.test.mjs
+++ b/test/stage3-envelope-pilots.test.mjs
@@ -1,0 +1,248 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import vm from "node:vm";
+
+import {
+  buildSiteResultEnvelope,
+  unwrapSiteAdapterCarrier,
+  SITE_RESULT_ENVELOPE_VERSION,
+} from "/private/tmp/pinix-edge-170-stage3/main/site-envelope.mjs";
+import {
+  buildEnabledSiteIndex,
+} from "/private/tmp/pinix-edge-170-stage3/main/handlers/site.mjs";
+
+async function loadJSON(path) {
+  return JSON.parse(await readFile(new URL(path, import.meta.url), "utf8"));
+}
+
+async function loadAdapter(path, fetchImpl) {
+  const source = await readFile(new URL("../" + path, import.meta.url), "utf8");
+  const patched = source.replace(/async function\s*\(\s*args\s*\)\s*\{/, "globalThis.__adapter = async function(args) {");
+  const context = vm.createContext({ fetch: fetchImpl, console, URL, globalThis: {} });
+  vm.runInContext(patched, context, { filename: path });
+  assert.equal(typeof context.globalThis.__adapter, "function");
+  return context.globalThis.__adapter;
+}
+
+function response(body, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: async () => body
+  };
+}
+
+function envelopeFor(siteName, commandName, manifest, result, args = {}) {
+  const cmdMeta = manifest.commands[commandName];
+  return buildSiteResultEnvelope({
+    siteName,
+    commandName,
+    manifest,
+    cmdMeta,
+    args,
+    profile: siteName === "reddit" ? "default" : undefined,
+    result,
+    retrievedAt: "2026-08-05T00:00:00.000Z"
+  });
+}
+
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test("manifests expose Stage3 metadata for only the selected pilot commands", async () => {
+  const hn = await loadJSON("../hackernews/site.json");
+  const reddit = await loadJSON("../reddit/site.json");
+
+  assert.deepEqual(Object.keys(hn.commands).sort(), ["thread", "top"]);
+  assert.equal(hn.commands.top.envelope_versions[0], SITE_RESULT_ENVELOPE_VERSION);
+  assert.equal(hn.commands.thread.auth, "none");
+  assert.equal(hn.commands.thread.side_effect, "read_only");
+  assert.equal(hn.commands.search, undefined);
+  assert.equal(hn.commands.user, undefined);
+
+  assert.equal(reddit.commands.search.envelope_versions[0], SITE_RESULT_ENVELOPE_VERSION);
+  assert.equal(reddit.commands.thread.auth, "optional");
+  assert.equal(reddit.commands.thread.profile, "required");
+  assert.equal(reddit.commands["user-comments"], undefined);
+  assert.equal(reddit.commands.context.output_modes[0], "legacy");
+
+  const catalog = buildEnabledSiteIndex({
+    data: [
+      { alias: "hackernews", scope: "pinix", name: "hackernews", active_version: hn.version, active_hash: "sha256:hn", download_url: "/hn.tgz", commands: Object.entries(hn.commands).map(([name, meta]) => ({ name, ...meta })) },
+      { alias: "reddit", scope: "pinix", name: "reddit", active_version: reddit.version, active_hash: "sha256:reddit", download_url: "/reddit.tgz", commands: Object.entries(reddit.commands).map(([name, meta]) => ({ name, ...meta })) }
+    ]
+  });
+  assert.equal(catalog.get("hackernews").commands.find((cmd) => cmd.name === "top").envelope_versions[0], SITE_RESULT_ENVELOPE_VERSION);
+  assert.equal(catalog.get("reddit").commands.find((cmd) => cmd.name === "thread").serialization_key, "site:reddit:{profile}");
+});
+
+test("hackernews top returns legacy-shaped data plus carrier metadata", async () => {
+  const fixture = await loadJSON("../fixtures/hackernews/top.json");
+  const manifest = await loadJSON("../hackernews/site.json");
+  const adapter = await loadAdapter("hackernews/top.js", async (url) => {
+    if (url.endsWith("/topstories.json")) return response(fixture.normal.ids);
+    const id = url.match(/item\/(\d+)\.json/)?.[1];
+    return response(fixture.normal.items[id] || null);
+  });
+
+  const result = await adapter({ count: "2" });
+  const legacy = unwrapSiteAdapterCarrier(result, manifest.commands.top);
+  assert.deepEqual(plain(legacy), {
+    count: 2,
+    posts: [
+      { rank: 1, id: 101, title: "First HN story", url: "https://example.com/first", hn_url: "https://news.ycombinator.com/item?id=101", author: "alice", score: 42, comments: 7 },
+      { rank: 2, id: 102, title: "Second HN story", url: null, hn_url: "https://news.ycombinator.com/item?id=102", author: "bob", score: 11, comments: 0 }
+    ]
+  });
+
+  const env = envelopeFor("hackernews", "top", manifest, result, { count: "2" });
+  assert.equal(env.status, "ok");
+  assert.equal(env.completeness, "partial");
+  assert.equal(env.reason, "limit_truncated");
+  assert.deepEqual(env.command.effective_args, { count: 2 });
+  assert.equal(env.source.url, "https://hacker-news.firebaseio.com/v0/topstories.json");
+  assert.deepEqual(env.pagination, { limit: 2, returned: 2, total_available: 3, truncated: true });
+  assert.deepEqual(env.auth, { requirement: "none", authenticated_as: "not_applicable" });
+});
+
+test("hackernews top covers empty and limit clamp without live fetch", async () => {
+  const fixture = await loadJSON("../fixtures/hackernews/top.json");
+  const manifest = await loadJSON("../hackernews/site.json");
+  const emptyAdapter = await loadAdapter("hackernews/top.js", async () => response(fixture.empty.ids));
+  const empty = envelopeFor("hackernews", "top", manifest, await emptyAdapter({ count: "5" }), { count: "5" });
+  assert.equal(empty.completeness, "empty");
+  assert.deepEqual(plain(empty.data), { count: 0, posts: [] });
+
+  const ids = Array.from({ length: 51 }, (_, i) => i + 1);
+  const adapter = await loadAdapter("hackernews/top.js", async (url) => {
+    if (url.endsWith("/topstories.json")) return response(ids);
+    const id = Number(url.match(/item\/(\d+)\.json/)?.[1]);
+    return response({ id, type: "story", title: "Story " + id, by: "u", score: id, descendants: 0 });
+  });
+  const env = envelopeFor("hackernews", "top", manifest, await adapter({ count: "500" }), { count: "500" });
+  assert.equal(env.command.effective_args.count, 50);
+  assert.equal(env.pagination.returned, 50);
+  assert.equal(env.pagination.truncated, true);
+});
+
+test("hackernews top covers invalid and network paths without live fetch", async () => {
+  const adapter = await loadAdapter("hackernews/top.js", async () => response({unexpected: true}));
+  assert.deepEqual(plain(await adapter({ count: "1" })), {
+    error: "Unexpected response",
+    hint: "HN Firebase topstories response was not a list"
+  });
+
+  const networkAdapter = await loadAdapter("hackernews/top.js", async () => { throw new Error("network down"); });
+  await assert.rejects(() => networkAdapter({ count: "1" }), /network down/);
+});
+
+test("hackernews thread omits deleted/dead and reports proven partial depth truncation", async () => {
+  const fixture = await loadJSON("../fixtures/hackernews/thread.json");
+  const manifest = await loadJSON("../hackernews/site.json");
+  const adapter = await loadAdapter("hackernews/thread.js", async (url) => {
+    const id = url.match(/item\/(\d+)\.json/)?.[1];
+    return response(fixture.items[id] || null);
+  });
+  const result = await adapter({ id: "https://news.ycombinator.com/item?id=200", depth: "0" });
+  const legacy = unwrapSiteAdapterCarrier(result, manifest.commands.thread);
+  assert.equal(legacy.post.id, 200);
+  assert.equal(legacy.comments.length, 1);
+  assert.equal(legacy.comments[0].id, 201);
+  assert.deepEqual(plain(legacy.comments[0].replies), []);
+
+  const env = envelopeFor("hackernews", "thread", manifest, result, { id: "https://news.ycombinator.com/item?id=200", depth: "0" });
+  assert.equal(env.completeness, "partial");
+  assert.equal(env.reason, "comments_omitted");
+  assert.deepEqual(env.command.effective_args, { id: "200", depth: 0 });
+  assert.equal(env.pagination.deleted_dead_omitted, 2);
+  assert.equal(env.pagination.depth_truncated, 1);
+});
+
+test("hackernews thread covers invalid and network paths", async () => {
+  const adapter = await loadAdapter("hackernews/thread.js", async () => response(null));
+  assert.deepEqual(plain(await adapter({})), {
+    error: "Missing argument: id",
+    hint: "Provide an HN item ID or item URL"
+  });
+  assert.deepEqual(plain(await adapter({ id: "999" })), {
+    error: "Item not found",
+    hint: "Check the ID: 999"
+  });
+
+  const networkAdapter = await loadAdapter("hackernews/thread.js", async () => { throw new Error("network down"); });
+  await assert.rejects(() => networkAdapter({ id: "999" }), /network down/);
+});
+
+test("reddit search returns listing data, after cursor, optional auth and redacted envelope", async () => {
+  const fixture = await loadJSON("../fixtures/reddit/search.json");
+  const manifest = await loadJSON("../reddit/site.json");
+  const adapter = await loadAdapter("reddit/search.js", async (url, options) => {
+    assert.equal(options.credentials, "include");
+    assert.match(url, /^\/search\.json\?/);
+    return response(fixture.normal);
+  });
+  const args = { query: "coding agents", sort: "top", time: "week", count: "2" };
+  const result = await adapter(args);
+  const legacy = unwrapSiteAdapterCarrier(result, manifest.commands.search);
+  assert.equal(legacy.query, "coding agents");
+  assert.equal(legacy.count, 1);
+  assert.equal(legacy.after, "t3_after");
+
+  const env = envelopeFor("reddit", "search", manifest, result, args);
+  assert.equal(env.completeness, "partial");
+  assert.deepEqual(plain(env.command.effective_args), { query: "coding agents", sort: "top", time: "week", count: 2 });
+  assert.equal(env.source.url, "https://www.reddit.com/search.json?q=coding%20agents&sort=top&t=week&limit=2&raw_json=1");
+  assert.deepEqual(plain(env.pagination), { limit: 2, returned: 1, after: "t3_after" });
+  assert.deepEqual(plain(env.auth), { requirement: "optional", authenticated_as: "unknown" });
+});
+
+test("reddit search covers empty, invalid and network paths", async () => {
+  const fixture = await loadJSON("../fixtures/reddit/search.json");
+  const manifest = await loadJSON("../reddit/site.json");
+  const adapter = await loadAdapter("reddit/search.js", async () => response(fixture.empty));
+  const empty = envelopeFor("reddit", "search", manifest, await adapter({ query: "none" }), { query: "none" });
+  assert.equal(empty.completeness, "empty");
+  assert.equal(empty.data.count, 0);
+
+  const invalid = await adapter({});
+  assert.deepEqual(plain(invalid), { error: "Missing argument: query", hint: "Provide a search query" });
+
+  const networkAdapter = await loadAdapter("reddit/search.js", async () => { throw Object.assign(new Error("network down"), { code: "NETWORK_DOWN" }); });
+  await assert.rejects(() => networkAdapter({ query: "x" }), /network down/);
+});
+
+test("reddit thread reports two-array comments, more placeholder and depth-limit partial", async () => {
+  const fixture = await loadJSON("../fixtures/reddit/thread.json");
+  const manifest = await loadJSON("../reddit/site.json");
+  const adapter = await loadAdapter("reddit/thread.js", async (url, options) => {
+    assert.equal(options.credentials, "include");
+    assert.equal(url, "/r/AI_Agents/comments/post/.json?limit=2&depth=0&raw_json=1");
+    return response(fixture.normal);
+  });
+
+  const args = { url: "https://www.reddit.com/r/AI_Agents/comments/post/thread-slug/?utm_source=secret#frag", depth: "0", count: "2" };
+  const result = await adapter(args);
+  const legacy = unwrapSiteAdapterCarrier(result, manifest.commands.thread);
+  assert.equal(legacy.post.id, "t3_post");
+  assert.equal(legacy.comments_total, 1);
+  assert.equal(legacy.comments[0].id, "t1_a");
+
+  const env = envelopeFor("reddit", "thread", manifest, result, args);
+  assert.equal(env.completeness, "partial");
+  assert.equal(env.reason, "comments_omitted");
+  assert.deepEqual(plain(env.command.effective_args), { url: "https://www.reddit.com/r/AI_Agents/comments/post/", depth: 0, count: 2 });
+  assert.equal(env.source.url, "https://www.reddit.com/r/AI_Agents/comments/post/.json?limit=2&depth=0&raw_json=1");
+  assert.equal(env.pagination.more_children_omitted, 2);
+  assert.equal(env.pagination.depth_truncated, 1);
+});
+
+test("reddit thread invalid and network paths remain legacy-compatible", async () => {
+  const adapter = await loadAdapter("reddit/thread.js", async () => response({}));
+  assert.deepEqual(plain(await adapter({})), { error: "Missing argument: url", hint: "Provide a Reddit post URL" });
+  assert.deepEqual(plain(await adapter({ url: "https://www.reddit.com/r/x/comments/y/z/" })), { error: "Unexpected response", hint: "Post may be deleted or URL is incorrect" });
+
+  const networkAdapter = await loadAdapter("reddit/thread.js", async () => { throw new Error("network down"); });
+  await assert.rejects(() => networkAdapter({ url: "https://www.reddit.com/r/x/comments/y/z/" }), /network down/);
+});

--- a/test/stage3-envelope-pilots.test.mjs
+++ b/test/stage3-envelope-pilots.test.mjs
@@ -1,8 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { access, readFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { access, mkdir, mkdtemp, readFile, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import vm from "node:vm";
 
 const edgeRepoEnv = process.env.PINIX_EDGE_REPO;
@@ -67,6 +68,79 @@ function envelopeFor(siteName, commandName, manifest, result, args = {}) {
 
 function plain(value) {
   return JSON.parse(JSON.stringify(value));
+}
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, "..");
+
+function createFakeDebugger(fetchImpl) {
+  let attached = false;
+  const context = vm.createContext({ fetch: fetchImpl, console, URL, globalThis: {} });
+  return {
+    isAttached: () => attached,
+    attach: () => { attached = true; },
+    detach: () => { attached = false; },
+    async sendCommand(method, params) {
+      if (method !== "Runtime.evaluate") throw new Error("Unexpected CDP method: " + method);
+      try {
+        const value = await vm.runInContext(params.expression, context, { timeout: 60000 });
+        return { result: { value } };
+      } catch (error) {
+        return {
+          exceptionDetails: {
+            text: error.message,
+            exception: { description: error.stack || error.message }
+          }
+        };
+      }
+    }
+  };
+}
+
+async function createActualHandler(fetchImpl) {
+  const home = await mkdtemp(join(tmpdir(), "bb-sites-stage3-actual-"));
+  await mkdir(join(home, ".pinix", "sites", "pinix"), { recursive: true });
+  await symlink(join(REPO_ROOT, "hackernews"), join(home, ".pinix", "sites", "pinix", "hackernews"), "dir");
+
+  const previousHome = process.env.HOME;
+  process.env.HOME = home;
+  let createSiteHandler;
+  try {
+    const handlerModuleURL = pathToFileURL(EDGE_SITE_HANDLER_PATH);
+    handlerModuleURL.search = "actual=" + Date.now() + "-" + Math.random();
+    ({ createSiteHandler } = await import(handlerModuleURL.href));
+  } finally {
+    process.env.HOME = previousHome;
+  }
+
+  const fakeDebugger = createFakeDebugger(fetchImpl);
+  const tab = {
+    id: "tab-actual-hn",
+    profile: "default",
+    view: { webContents: { debugger: fakeDebugger } }
+  };
+  return createSiteHandler({
+    syncOnExec: false,
+    tabManager: {
+      requireProfile(profile) {
+        if (!profile) throw new Error("actual handler test expected explicit profile");
+        return profile;
+      },
+      resolveTarget() {
+        return { tab };
+      },
+      async withCommandAttach(_tabId, _opts, fn) {
+        return await fn();
+      }
+    }
+  });
+}
+
+function hnThreadFetch(fixture) {
+  return async (url) => {
+    const id = url.match(/item\/(.+?)\.json/)?.[1];
+    return response(fixture.items[id] || null);
+  };
 }
 
 test("manifests expose Stage3 metadata for only the selected pilot commands", async () => {
@@ -206,10 +280,7 @@ test("hackernews top covers invalid and network paths without live fetch", async
 test("hackernews thread omits deleted/dead and reports proven partial depth truncation", async () => {
   const fixture = await loadJSON("../fixtures/hackernews/thread.json");
   const manifest = await loadJSON("../hackernews/site.json");
-  const adapter = await loadAdapter("hackernews/thread.js", async (url) => {
-    const id = url.match(/item\/(\d+)\.json/)?.[1];
-    return response(fixture.items[id] || null);
-  });
+  const adapter = await loadAdapter("hackernews/thread.js", hnThreadFetch(fixture));
   const threadArgs = { id: "https://news.ycombinator.com/item?id=200&token=fake#frag", depth: "0" };
   const result = await adapter(threadArgs);
   const legacy = unwrapSiteAdapterCarrier(result, manifest.commands.thread);
@@ -229,13 +300,59 @@ test("hackernews thread omits deleted/dead and reports proven partial depth trun
   assert.equal(env.pagination.top_level_comments_returned, 1);
 });
 
+test("hackernews thread actual Edge handler accepts numeric token ids", async () => {
+  const fixture = await loadJSON("../fixtures/hackernews/thread.json");
+  const handler = await createActualHandler(hnThreadFetch(fixture));
+
+  const defaultResult = await handler.exec({ command: "hackernews thread --id 200 --depth 0", profile: "default" }, {});
+  assert.equal(defaultResult.__pinix_site_result, undefined);
+  assert.equal(defaultResult.post.id, 200);
+  assert.equal(defaultResult.comments.length, 1);
+
+  const env = await handler.exec({ command: "hackernews thread --id 200 --depth 0 --envelope v1", profile: "default" }, {});
+  assert.equal(env.status, "ok");
+  assert.equal(env.data.post.id, 200);
+  assert.deepEqual(plain(env.command.requested_args), { id: 200, depth: 0 });
+  assert.deepEqual(plain(env.command.effective_args), { id: "200", depth: 0 });
+});
+
+test("hackernews thread actual Edge handler accepts string numeric and URL ids", async () => {
+  const fixture = await loadJSON("../fixtures/hackernews/thread.json");
+  const handler = await createActualHandler(hnThreadFetch(fixture));
+
+  const stringNumeric = await handler.exec({ command: "hackernews thread --id 1234567890123456 --depth 1 --envelope v1", profile: "default" }, {});
+  assert.equal(stringNumeric.status, "ok");
+  assert.deepEqual(plain(stringNumeric.command.requested_args), { id: "1234567890123456", depth: 1 });
+  assert.deepEqual(plain(stringNumeric.command.effective_args), { id: "1234567890123456", depth: 1 });
+
+  const urlId = await handler.exec({ command: "hackernews thread --id \"https://news.ycombinator.com/item?id=200&token=fake#frag\" --depth 0 --envelope v1", profile: "default" }, {});
+  assert.equal(urlId.status, "ok");
+  assert.deepEqual(plain(urlId.command.requested_args), { id: "https://news.ycombinator.com/item?id=200", depth: 0 });
+  assert.deepEqual(plain(urlId.command.effective_args), { id: "200", depth: 0 });
+});
+
+test("hackernews thread actual Edge handler preserves missing null and invalid semantics", async () => {
+  const fixture = await loadJSON("../fixtures/hackernews/thread.json");
+  const handler = await createActualHandler(hnThreadFetch(fixture));
+
+  assert.deepEqual(plain(await handler.exec({ command: "hackernews thread --depth 1", profile: "default" }, {})), {
+    error: "Missing argument: id",
+    hint: "Provide an HN item ID or item URL"
+  });
+  assert.deepEqual(plain(await handler.exec({ command: "hackernews thread --id null --depth 1", profile: "default" }, {})), {
+    error: "Missing argument: id",
+    hint: "Provide an HN item ID or item URL"
+  });
+  assert.deepEqual(plain(await handler.exec({ command: "hackernews thread --id 999 --depth 1", profile: "default" }, {})), {
+    error: "Item not found",
+    hint: "Check the ID: 999"
+  });
+});
+
 test("hackernews thread counts nested comments recursively", async () => {
   const fixture = await loadJSON("../fixtures/hackernews/thread.json");
   const manifest = await loadJSON("../hackernews/site.json");
-  const adapter = await loadAdapter("hackernews/thread.js", async (url) => {
-    const id = url.match(/item\/(\d+)\.json/)?.[1];
-    return response(fixture.items[id] || null);
-  });
+  const adapter = await loadAdapter("hackernews/thread.js", hnThreadFetch(fixture));
   const env = envelopeFor("hackernews", "thread", manifest, await adapter({ id: "210", depth: "2" }), { id: "210", depth: "2" });
   assert.equal(env.completeness, "complete");
   assert.equal(env.pagination.comments_returned, 2);
@@ -245,10 +362,7 @@ test("hackernews thread counts nested comments recursively", async () => {
 test("hackernews thread reports deleted/dead root as non-complete metadata without changing legacy data", async () => {
   const fixture = await loadJSON("../fixtures/hackernews/thread.json");
   const manifest = await loadJSON("../hackernews/site.json");
-  const adapter = await loadAdapter("hackernews/thread.js", async (url) => {
-    const id = url.match(/item\/(\d+)\.json/)?.[1];
-    return response(fixture.items[id] || null);
-  });
+  const adapter = await loadAdapter("hackernews/thread.js", hnThreadFetch(fixture));
 
   const deletedResult = await adapter({ id: "220" });
   const deletedLegacy = unwrapSiteAdapterCarrier(deletedResult, manifest.commands.thread);


### PR DESCRIPTION
## Stage3 bb-sites result envelope pilots

This PR implements the bb-sites side of epiral/pinix#170 Stage3 for four read-only pilot commands only:

- `hackernews top`
- `hackernews thread`
- `reddit search`
- `reddit thread`

No HN search/user, no Reddit user-comments, no #171 ledger, no production deployment, no live provider calls.

## Cross-head evidence

Final validated heads:

- API: `18f185c`
- Edge: `5df8b21`
- bb-sites: `74a15d28de84d9d27ca11e374a3a8cf059f7b7a4`

Final E2E / heavy-user status:

- Final cross-repo E2E: 0 blocker / READY.
- HN heavy-user validation: 0 blocker / READY.
- Reddit heavy-user validation: 0 blocker / READY.

## Contract

Each pilot command declares explicit manifest metadata:

- `auth`
- `profile`
- `side_effect=read_only`
- `retry_safety`
- `max_concurrency`
- `serialization_key`
- `output_modes`
- `timeout_class`
- `envelope_versions=[pinix.site-result-envelope.v1]`
- non-sensitive params

Adapters return a versioned carrier:

- `__pinix_site_result.version = pinix.site-adapter-result.v1`
- `__pinix_site_result.metadata` contains only allowlisted direct-evidence fields
- `data` preserves the exact legacy result shape

Default output remains legacy-compatible through Edge unwrap. Envelope output is opt-in.

## HN coverage

Validated by deterministic fixtures and actual Edge handler tests:

- `hackernews top` complete, empty, limit truncation, selected-item omissions.
- Selected omissions report stable counts for missing, deleted/dead, non-story, and missing-title candidates.
- `hackernews thread` deleted/dead root reports `root_unavailable` metadata without changing default legacy data.
- `hackernews thread` recursive `comments_returned` and explicit `top_level_comments_returned`.
- Depth/fanout/deleted child partial counts remain covered.
- Actual Edge handler covers numeric token ID parse behavior:
  - default `--id 200` succeeds and unwraps carrier data
  - opt-in `--id 200 --envelope v1` succeeds with requested numeric ID and effective string ID
  - long numeric string ID succeeds
  - URL ID with synthetic sensitive query/fragment is sanitized by Edge
  - missing/null/invalid semantics remain stable

## Reddit coverage

Validated by deterministic fixtures:

- `reddit search` normal listing, empty, cursor/after pagination, effective sort/time/limit, invalid, network.
- `reddit thread` two-array post/comments response, `more`, depth/limit partial, invalid, network.
- Reddit auth remains `optional`; `authenticated_as` remains `unknown` because profile/cookie presence does not prove identity.

## Validation commands

Exact Edge checkout used for current validation:

```sh
git -C /private/tmp/pinix-edge-170-stage3-final rev-parse HEAD
# 5df8b21a8a89a4564e3fd9ddfd416f9f8b4cd430

PINIX_EDGE_REPO=/private/tmp/pinix-edge-170-stage3-final node --test test/stage3-envelope-pilots.test.mjs
# pass 16/16
```

Additional checks:

```sh
# in /private/tmp/pinix-edge-170-stage3-final
node --test test/site-envelope.test.mjs test/site-sync.test.mjs
# pass 19/19

# in bb-sites pilot worktree
node <legacy anonymous adapter syntax probe>
# syntax-ok hackernews/top.js
# syntax-ok hackernews/thread.js
# syntax-ok reddit/search.js
# syntax-ok reddit/thread.js

git diff --check HEAD~1..HEAD
# pass
```

## Limits / deferred

- No live HN/Reddit calls; all validation is deterministic fixtures and fake CDP.
- `retrieved_at` is Edge/runtime retrieval time, not provider freshness.
- Stage3 reports concurrency metadata; it does not enforce queueing or SITE_BUSY.
- HN search/user and Reddit user-comments are deferred.
- #171 durable operation ledger is out of scope.
- No merge/deploy/restart/config/DB changes in this PR.
