### PR TITLE
fix(hackernews): use same-origin Firebase context

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,10 @@ async function(args) {
 }
 ```
 
+`domain` is the exact HTTPS execution and `fetch()` origin. Keep requests on
+that origin. If the domain root redirects elsewhere, add a same-origin
+`"startPath": "/stable/path"` to establish the browser context.
+
 ### Tier Guide
 
 | Tier | Auth | Example | Time |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -30,7 +30,12 @@ Site adapter 在浏览器 tab 里通过 `eval` 执行。你的代码运行在别
 
 **绝对 URL 是最常见的 adapter 故障根因。** 不是代码逻辑错了，是身份搞错了。fetch 一个完整 URL 意味着你在告诉浏览器："我要以 google.com 的身份去访问 bing.com" —— 浏览器不会允许。
 
-推论：**永远用相对路径**，除非目标 API 明确开放了 CORS（`Access-Control-Allow-Origin: *`）。
+推论：**永远用相对路径**。如果数据 API 在另一个 origin，把 `domain`
+改成 API host；Tap 会在请求发出前拒绝跨域 fetch，不能靠 CORS 放行。
+
+推论：**根路径不一定是执行入口**。如果 `https://{domain}/` 会重定向到
+别的 origin，用 `startPath` 指向同域稳定页面，例如 Firebase adapter 使用
+`"startPath": "/v0/topstories.json"`。
 
 推论：**域名重定向是隐形杀手**。`zzk.cnblogs.com` 静默重定向到 `zzkx.cnblogs.com`，你的 domain 配置瞬间失效。在浏览器里实际打开 URL，看最终落在哪个域名。
 
@@ -264,7 +269,8 @@ Agent 先看 `error` 判断能否自动处理，再看 `action` 尝试修复，�
 写完一个 adapter 后，过一遍：
 
 - [ ] `@meta.domain` 是浏览器实际落地的域名（打开 URL 确认，注意重定向和子域名）
-- [ ] 所有 fetch 用相对路径（除非目标有 CORS 头）
+- [ ] 所有 fetch 与 `@meta.domain` 完全同源
+- [ ] 根路径会跨域重定向时配置同源 `startPath`
 - [ ] SSR 站点 → DOM 解析，CSR 站点 → API/JS 函数
 - [ ] 有反爬检测逻辑，返回 error + hint + action
 - [ ] 搜索结果精简（无大图 URL、无全文、无冗余字段、无 tracking 参数）

--- a/SKILL.md
+++ b/SKILL.md
@@ -103,6 +103,9 @@ async function(args) {
 }
 ```
 
+`domain` 必须是实际执行和 `fetch()` 的 HTTPS host；不要跨域请求。若根路径
+会跳到其他 origin，增加同域 `startPath` 作为稳定执行入口。
+
 **判断标准**: 用 `bb-browser eval "fetch('/api/xxx', {credentials:'include'}).then(r=>r.json())"` 能直接拿到数据。
 
 ### Tier 2: `eval` + 手动 header

--- a/hackernews/thread.js
+++ b/hackernews/thread.js
@@ -2,7 +2,8 @@
 {
   "name": "hackernews/thread",
   "description": "获取 Hacker News 帖子的评论树",
-  "domain": "news.ycombinator.com",
+  "domain": "hacker-news.firebaseio.com",
+  "startPath": "/v0/topstories.json",
   "args": {
     "id": {"required": true, "description": "HN item ID or URL"},
     "depth": {"required": false, "description": "Comment tree depth (default: 2, max: 5)"}

--- a/hackernews/top.js
+++ b/hackernews/top.js
@@ -2,7 +2,8 @@
 {
   "name": "hackernews/top",
   "description": "获取 Hacker News 当前热门帖子",
-  "domain": "news.ycombinator.com",
+  "domain": "hacker-news.firebaseio.com",
+  "startPath": "/v0/topstories.json",
   "args": {
     "count": {"required": false, "description": "Number of posts (default: 20, max: 50)"}
   },


### PR DESCRIPTION
## Summary

- run Hacker News adapters from the Firebase API origin they actually fetch
- add a stable same-origin `startPath` because the Firebase root redirects to Google sign-in
- document the exact-origin adapter contract

## Root cause

Both HN adapters declare `news.ycombinator.com` but fetch `hacker-news.firebaseio.com`. Browser execution therefore depends on cross-origin CORS/CSP behavior and currently fails under Tap with `TypeError: Failed to fetch`.

## Verification

Tested with the Tap domain-guard build in a fresh agent-browser session:

- `hackernews/top count=2` returned two stories
- `hackernews/thread` returned the selected post and 23 comments
- reverting the metadata produces the expected deterministic `Tap cross-origin fetch blocked` error
